### PR TITLE
Repaired default and nondefault options

### DIFF
--- a/iexfinance/iexretriever.py
+++ b/iexfinance/iexretriever.py
@@ -101,8 +101,8 @@ class IEXRetriever(object):
 
 
         self._ENDPOINTS = {
-                    "quote" : { "options" : [("displayPercent",self.displayPercent)]},
                     "chart" : {"options" : [("range", self.chartRange)]},
+                    "quote" : { "options" : [("displayPercent",self.displayPercent)]},
                     "book" : {"options" : None},
                     "open-close" : {"options" : None},
                     "previous" : {"options" : None},
@@ -266,6 +266,9 @@ class IEXRetriever(object):
                         data_set[symbol].update(oresponse)
                 except:
                     raise IEXSymbolError(symbol)
+                diff = set(self._ENDPOINTS) - set(data_set[symbol])
+                for item in diff:
+                    data_set[symbol].update({item: []})
                 if set(data_set[symbol]) != set(self._ENDPOINTS):
                     raise ValueError("Not all endpoints downloaded")
         return data_set


### PR DESCRIPTION
Fixes #2 

**Default options**

Ensured that the chart parameter would be passed ahead of the others. See iexg/IEX-API#156, as this seems to be a temporary workaround (will need to repair once they fix on their end)

**Non-default options**

Endpoints that returned empty from the query (i.e. a company with no recent splits such as AAPL) were not updating themselves in the dataset. For those endpoints we added code which manually inserts an empty list for those endpoints.