### PR TITLE
COMPAT: Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: python
 
 python:
-- "3.5"
-
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  
 install: 
   - pip install -qq flake8
   - pip install codecov

--- a/iexfinance/market.py
+++ b/iexfinance/market.py
@@ -64,7 +64,7 @@ class Market(_IEXBase):
             try:
                 df = pd.DataFrame(response)
                 return df
-            except ValueError as e:
+            except ValueError:
                 raise IEXQueryError()
         elif self.acc_pandas is False:
             raise ValueError("Pandas not accepted for this function.")

--- a/iexfinance/stats.py
+++ b/iexfinance/stats.py
@@ -31,7 +31,7 @@ class Stats(_IEXBase):
             try:
                 df = pd.DataFrame(response)
                 return df
-            except ValueError as e:
+            except ValueError:
                 raise IEXQueryError()
         elif self.acc_pandas is False:
             raise ValueError("Pandas not accepted for this function.")

--- a/setup.py
+++ b/setup.py
@@ -74,13 +74,11 @@ setup(
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6'
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
Repairs compatibility discrepancies between pypi and travis 
* Removes listed support for python 2.6, 3.3
* Adds 3.4, 3.6, 2.7 support to TravisCI

Fixes #18 