### PR TITLE
Stocks refactor

### DIFF
--- a/docs/source/ref.rst
+++ b/docs/source/ref.rst
@@ -139,7 +139,8 @@ Usage
 IEX Listed Symbol Directory
 ===========================
 
-Similar to `Symbols <ref.symbols>`, `IEX Listed Symbol Directory<https://iextrading.com/developer/docs/#iex-listed-symbol-directory>`__ returns an array of all IEX listed securities.
+Similar to :ref:`Symbol<ref.symbols>`, `IEX Listed Symbol Directory
+<https://iextrading.com/developer/docs/#iex-listed-symbol-directory>`__ returns an array of all IEX listed securities.
 
 Access is available through the top-level function ``get_iex_listed_symbol_dir``
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -30,14 +30,6 @@ All classes and functions utilize the _IEXBASE class to make their requests:
 
 .. autoclass:: iexfinance.base._IEXBase
 
-
-Caching
--------
-
-iexfinance supports the caching of HTTP requests to IEX using the ``requests-cache`` package.
-
-.. seealso:: `Caching Queries <caching.html>`__
-
 .. _usage.stocks:
 
 Stocks
@@ -57,12 +49,10 @@ Endpoints
 The Stock endpoints of the `IEX Developer
 API <https://iextrading.com/developer/>`__ are below, each of which
 contains data regarding a different aspect of the security/securities.
-Both the `Share <stocks.html#share>`__ and `Batch <stocks.html#batch>`__
-objects contain identically-signatured functions which can obtain each
-of these endpoints. Requests for single symbols (`Share <stocks.html#share>`__)
-will return the *exact* results from that endpoint as shown in the IEX API
-documentation (see below). Requests for multiple symbols
-(`Batch <stocks.html#batch>`__) will return a symbol-indexed dictionary of
+The `Stock <stocks.html>`__ function creates an object that can obtain each
+of these endpoints. Requests for single symbols will return the *exact* results
+from that endpoint as shown in the IEX API documentation (see below). Requests
+for multiple symbols will return a symbol-indexed dictionary of
 the endpoint requested.
 
 *Endpoint Method* Examples ``get_quote()``, ``get_volume_by_venue()``
@@ -77,7 +67,7 @@ the endpoint requested.
 
 
 For a detailed list of the *endpoint methods*, see
-`Share <stocks.html#share>`__ or `Batch <stocks.html#batch>`__.
+`Stocks <stocks.html#endpoints>`__.
 
 Fields
 ------
@@ -102,23 +92,31 @@ Examples ``get_open()``, ``get_name()``
     b.get_open()
 
 
-For a detailed list of these functions, see `Share <stocks.html#share>`__ or
-`Batch <stocks.html#batch>`__.
+For a detailed list of these functions, see `Stocks <stocks.html>`__.
 
 Parameters
 ----------
 
+Top-level parameters may be passed to the ``Stock`` function, including
+``output_format`` and request parameters (such as ``retry_count``, and
+``pause``) - the latter of which will be used should any queries made by
+the object fail. These parameters are passed keyword arguments, and are
+entirely optional.
+
 Certain endpoints (such as quote and chart) allow customizable
-parameters. To specify one of these parameters, merely pass it as a
-keyword argument.
+parameters. To specify one of these parameters, merely pass it to an endpoint
+method as a keyword argument. 
 
 .. ipython:: python
 
-    aapl = Stock("AAPL", displayPercent=True)
+    aapl = Stock("AAPL", output_format='pandas')
+    aapl.get_quote(displayPercent=True).loc["ytdChange"]
 
-
-.. note:: Due to collisions between the dividends and splits range options that require separate requests and merging. The single _range value specified will apply to the chart, dividends, and splits endpoints. We have contacted IEX about this issue and hope to resolve it soon.
-
+.. note:: The ``output_format`` from the initial
+  call to the ``Stock`` function will be used (if the output format has not been
+  change through ``change_output_format`` since) and **cannot be changed**
+  through calls to endpoint methods. See `Stocks <stocks.html>`__ for
+  more information.
 
 .. _usage.reference-data:
 
@@ -147,3 +145,12 @@ IEX Stats
 .. seealso:: For more information, see `IEX Stats <stats.html>`__
 
 The IEX Stats `endpoints <stats.html>`__
+
+.. _usage.caching
+
+Caching
+-------
+
+iexfinance supports the caching of HTTP requests to IEX using the ``requests-cache`` package.
+
+.. seealso:: `Caching Queries <caching.html>`__

--- a/iexfinance/__init__.py
+++ b/iexfinance/__init__.py
@@ -17,8 +17,7 @@ __version__ = '0.3.0'
 # and conditions of use
 
 
-def Stock(symbols=None, displayPercent=False, _range="1m", last=10,
-          output_format='json', **kwargs):
+def Stock(symbols=None, output_format='json', **kwargs):
     """
     Top-level function to to retrieve data from the IEX Stocks endpoints
 
@@ -26,13 +25,9 @@ def Stock(symbols=None, displayPercent=False, _range="1m", last=10,
     ----------
     symbols: str or list
         A string or list of strings that are valid symbols
-    displayPercent: bool
-    _range: str
-    last: int
     output_format: str
     kwargs:
         Additional request options
-
     Returns
     -------
     stock.StockReader
@@ -42,16 +37,14 @@ def Stock(symbols=None, displayPercent=False, _range="1m", last=10,
         if not symbols:
             raise ValueError("Please input a symbol or list of symbols")
         else:
-            inst = StockReader([symbols], displayPercent, _range, last,
-                               output_format, **kwargs)
+            inst = StockReader([symbols], output_format, **kwargs)
     elif type(symbols) is list:
         if not symbols:
             raise ValueError("Please input a symbol or list of symbols")
         if len(symbols) > 100:
             raise ValueError("Invalid symbol list. Maximum 100 symbols.")
         else:
-            inst = StockReader(symbols, displayPercent, _range, last,
-                               output_format, **kwargs)
+            inst = StockReader(symbols, output_format, **kwargs)
         return inst
     else:
         raise ValueError("Please input a symbol or list of symbols")

--- a/iexfinance/base.py
+++ b/iexfinance/base.py
@@ -105,6 +105,7 @@ class _IEXBase(object):
         IEXQueryError
             If problems arise when making the query
         """
+        print("REQUEST URL: " + url)
         pause = self.pause
         for i in range(self.retry_count+1):
 
@@ -138,5 +139,4 @@ class _IEXBase(object):
             A response object
         """
         url = self._prepare_query()
-        response = self._execute_iex_query(url)
-        return response
+        return self._execute_iex_query(url)

--- a/iexfinance/stock.py
+++ b/iexfinance/stock.py
@@ -38,6 +38,9 @@ def output_format(override=None):
                     import warnings
                     warnings.warn("Pandas output not supported for this "
                                   "endpoint. Defaulting to JSON.")
+                    if self.key is 'share':
+                        return response[self.symbols[0]]
+                    return response
             else:
                 if self.key is 'share':
                     return response[self.symbols[0]]
@@ -52,7 +55,6 @@ class StockReader(_IEXBase):
     _IEXBase, subclassed by Share, Batch, and HistoricalReader
     """
     # Possible option values (first is default)
-    _RANGE_VALUES = ['1m', '5y', '2y', '1y', 'ytd', '6m', '3m', '1d']
     _ENDPOINTS = ["chart", "quote", "book", "open-close", "previous",
                   "company", "stats", "peers", "relevant", "news",
                   "financials", "earnings", "dividends", "splits", "logo",
@@ -61,8 +63,7 @@ class StockReader(_IEXBase):
     ALL_ENDPOINTS_STR_1 = ",".join(_ENDPOINTS[:10])
     ALL_ENDPOINTS_STR_2 = ','.join(_ENDPOINTS[10:20])
 
-    def __init__(self, symbols=None, displayPercent=False, _range="1m",
-                 last=10, output_format='json', **kwargs):
+    def __init__(self, symbols=None, output_format='json', **kwargs):
         """ Initialize the class
 
         Parameters
@@ -84,54 +85,16 @@ class StockReader(_IEXBase):
         else:
             self.key = "batch"
         self.output_format = output_format
-        self.displayPercent = displayPercent
-        self.range = _range
-        self.last = last
         super(StockReader, self).__init__(**kwargs)
 
-        # Parameter checking
-        if not isinstance(self.displayPercent, bool):
-            raise TypeError("displayPercent must be a boolean value")
-        elif self.range not in self._RANGE_VALUES:
-            raise ValueError("Invalid chart range.")
-        elif int(self.last) > 50 or int(self.last) < 1:
-            raise ValueError(
-                "Invalid news last range. Enter a value between 1 and 50.")
-        self.refresh()
-
-    def _default_options(self):
-        return (self.range == '1m' and self.last == 10 and
-                self.displayPercent is False)
-
-    def refresh(self):
-        """
-        Downloads latest data from all Stock endpoints
-        """
-        self.endpoints = self.ALL_ENDPOINTS_STR_1
-        self.data_set = self.fetch()
-        self.endpoints = self.ALL_ENDPOINTS_STR_2
-        data2 = self.fetch()
-
-        for symbol in self.symbols:
-            if symbol not in self.data_set:
-                raise IEXSymbolError(symbol)
-            self.data_set[symbol].update(data2[symbol])
-
-    @property
-    def url(self):
-        return 'stock/market/batch'
-
-    @property
-    def params(self):
-        params = {
-            "symbols": ','.join(self.symbols),
-            "types": self.endpoints
-        }
-        if not self._default_options():
-            params["range"] = self.range
-            params["last"] = self.last
-            params["displayPercent"] = self.displayPercent
-        return params
+        # # Parameter checking
+        # if not isinstance(self.displayPercent, bool):
+        #     raise TypeError("displayPercent must be a boolean value")
+        # elif self.range not in self._RANGE_VALUES:
+        #     raise ValueError("Invalid chart range.")
+        # elif int(self.last) > 50 or int(self.last) < 1:
+        #     raise ValueError(
+        #         "Invalid news last range. Enter a value between 1 and 50.")
 
     @output_format(override='json')
     def get_all(self):
@@ -142,10 +105,46 @@ class StockReader(_IEXBase):
         -----
         Only allows JSON format (pandas not supported).
         """
-        return self.data_set
+        self.optional_params = {}
+        self.endpoints = self.ALL_ENDPOINTS_STR_1
+        json_data = self.fetch()
+        self.endpoints = self.ALL_ENDPOINTS_STR_2
+        json_data_2 = self.fetch()
+        for symbol in self.symbols:
+            if symbol not in json_data:
+                raise IEXSymbolError(symbol)
+            json_data[symbol].update(json_data_2[symbol])
+        return json_data
+
+    @property
+    def url(self):
+        return 'stock/market/batch'
+
+    @property
+    def params(self):
+        temp = {
+            "symbols": ','.join(self.symbols),
+            "types": self.endpoints
+        }
+        temp.update({key: str(self.optional_params[key])
+                     for key in self.optional_params})
+        params = {k.lower() if k[0].isupper() else k: v.lower() for k, v in
+                  temp.items()}
+        return params
+
+    def _get_endpoint(self, endpoint, params={}):
+        self.optional_params = params
+        self.endpoints = endpoint
+        data = self.fetch()
+        for symbol in self.symbols:
+            if symbol not in data:
+                raise IEXSymbolError(symbol)
+            elif endpoint not in data[symbol]:
+                raise IEXEndpointError(endpoint)
+        return data
 
     @output_format(override='json')
-    def get_select_endpoints(self, endpoints=[]):
+    def get_endpoints(self, endpoints=[]):
         """
         Universal selector method to obtain specific endpoints from the
         data set.
@@ -167,7 +166,7 @@ class StockReader(_IEXBase):
             If issues arise during query
         """
         if isinstance(endpoints, str):
-            endpoints = [endpoints]
+            return self._get_endpoint(endpoints)
         elif not endpoints:
             raise ValueError("Please provide a valid list of endpoints")
         result = {}
@@ -186,20 +185,6 @@ class StockReader(_IEXBase):
             result[symbol] = temp
         return result
 
-    # endpoint methods
-    @output_format(override=None)
-    def get_quote(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#quote
-
-        Returns
-        -------
-        dict or pandas.DataFrame
-            Stocks Quote endpoint data
-        """
-        return {symbol: self.data_set[symbol]["quote"] for symbol in
-                self.data_set.keys()}
-
     @output_format(override=None)
     def get_book(self):
         """
@@ -210,11 +195,11 @@ class StockReader(_IEXBase):
         list or pandas.DataFrame
             Stocks Book endpoint data
         """
-        return {symbol: self.data_set[symbol]["book"] for symbol in
-                self.data_set.keys()}
+        data = self._get_endpoint("book")
+        return {symbol: data[symbol]["book"] for symbol in list(data)}
 
     @output_format(override='json')
-    def get_chart(self):
+    def get_chart(self, **kwargs):
         """
         Reference: https://iextrading.com/developer/docs/#chart
 
@@ -227,8 +212,146 @@ class StockReader(_IEXBase):
         list
             Stocks Chart endpoint data
         """
-        return {symbol: self.data_set[symbol]["chart"] for symbol in
-                self.data_set.keys()}
+        data = self._get_endpoint("chart", kwargs)
+        return {symbol: data[symbol]["chart"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_company(self):
+        """
+        Reference: https://iextrading.com/developer/docs/#company
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks Company endpoint data
+        """
+        data = self._get_endpoint("company")
+        return {symbol: data[symbol]["company"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_delayed_quote(self):
+        """
+        Reference: https://iextrading.com/developer/docs/#delayed-quote
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks Delayed Quote endpoint data
+        """
+        data = self._get_endpoint("delayed-quote")
+        return {symbol: data[symbol]["delayed-quote"] for symbol in
+                list(data)}
+
+    @output_format(override='json')
+    def get_dividends(self, **kwargs):
+        """
+        Reference: https://iextrading.com/developer/docs/#dividends
+
+        Notes
+        -----
+        Pandas not supported for this method. list will be returned.
+
+        Returns
+        -------
+        list
+            Stocks Dividends endpoint data
+        """
+        data = self._get_endpoint("dividends", kwargs)
+        return {symbol: data[symbol]["dividends"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_earnings(self):
+        """
+        Reference: https://iextrading.com/developer/docs/#earnings
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks Earnings endpoint data
+        """
+        data = self._get_endpoint("earnings")
+        return {symbol: data[symbol]["earnings"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_effective_spread(self):
+        """
+        Reference:  https://iextrading.com/developer/docs/#effective-spread
+
+        Returns
+        -------
+        list or pandas.DataFrame
+            Stocks Effective Spread endpoint data
+        """
+        data = self._get_endpoint("effective-spread")
+        return {symbol: data[symbol]["effective-spread"] for symbol
+                in list(data)}
+
+    @output_format(override=None)
+    def get_financials(self):
+        """
+        Reference: https://iextrading.com/developer/docs/#financials
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks Financials endpoint data
+        """
+        data = self._get_endpoint("financials")
+        return {symbol: data[symbol]["financials"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_key_stats(self):
+        """
+        Reference: https://iextrading.com/developer/docs/#key-stats
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks Key Stats endpoint data
+        """
+        data = self._get_endpoint("stats")
+        return {symbol: data[symbol]["stats"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_logo(self):
+        """
+        Reference: https://iextrading.com/developer/docs/#logo
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks Logo endpoint data
+        """
+        data = self._get_endpoint("logo")
+        return {symbol: data[symbol]["logo"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_news(self, **kwargs):
+        """Returns the Stocks News endpoint (list or pandas)
+
+        Reference: https://iextrading.com/developer/docs/#news
+
+        Returns
+        -------
+        list or pandas.DataFrame
+            Stocks News endpoint data
+        """
+        data = self._get_endpoint("news", kwargs)
+        return {symbol: data[symbol]["news"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_ohlc(self):
+        """
+        Reference:  https://iextrading.com/developer/docs/#ohlc
+
+        Returns
+        -------
+        dict or pandas.DataFrame
+            Stocks OHLC endpoint data
+        """
+        data = self._get_endpoint("ohlc")
+        return {symbol: data[symbol]["ohlc"] for symbol
+                in list(data)}
 
     def get_open_close(self):
         """
@@ -246,6 +369,23 @@ class StockReader(_IEXBase):
         """
         return self.get_ohlc()
 
+    @output_format(override='json')
+    def get_peers(self):
+        """
+        Reference:https://iextrading.com/developer/docs/#peers
+
+        Notes
+        -----
+        Only allows JSON format (pandas not supported).
+
+        Returns
+        -------
+        list
+            Stocks Peers endpoint data
+        """
+        data = self._get_endpoint("peers")
+        return {symbol: data[symbol]["peers"] for symbol in list(data)}
+
     @output_format(override=None)
     def get_previous(self):
         """
@@ -256,139 +396,8 @@ class StockReader(_IEXBase):
         dict or pandas.DataFrame
             Stocks Previous endpoint data
         """
-        return {symbol: self.data_set[symbol]["previous"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_company(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#company
-
-        Returns
-        -------
-        dict or pandas.DataFrame
-            Stocks Company endpoint data
-        """
-        return {symbol: self.data_set[symbol]["company"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_key_stats(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#key-stats
-
-        Returns
-        -------
-        dict or pandas.DataFrame
-            Stocks Key Stats endpoint data
-        """
-        return {symbol: self.data_set[symbol]["stats"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_peers(self):
-        """
-        Reference:https://iextrading.com/developer/docs/#peers
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks Peers endpoint data
-        """
-        return {symbol: self.data_set[symbol]["peers"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_relevant(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#relevant
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks Relevant endpoint data
-        """
-        return {symbol: self.data_set[symbol]["relevant"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_news(self):
-        """Returns the Stocks News endpoint (list or pandas)
-
-        Reference: https://iextrading.com/developer/docs/#news
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks News endpoint data
-        """
-        return {symbol: self.data_set[symbol]["news"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_financials(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#financials
-
-        Returns
-        -------
-        dict or pandas.DataFrame
-            Stocks Financials endpoint data
-        """
-        return {symbol: self.data_set[symbol]["financials"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_earnings(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#earnings
-
-        Returns
-        -------
-        dict or pandas.DataFrame
-            Stocks Earnings endpoint data
-        """
-        return {symbol: self.data_set[symbol]["earnings"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_dividends(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#dividends
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks Dividends endpoint data
-        """
-        return {symbol: self.data_set[symbol]["dividends"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_splits(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#splits
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks Splits endpoint data
-        """
-        return {symbol: self.data_set[symbol]["splits"] for symbol in
-                self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_logo(self):
-        """
-        Reference: https://iextrading.com/developer/docs/#logo
-
-        Returns
-        -------
-        dict or pandas.DataFrame
-            Stocks Logo endpoint data
-        """
-        return {symbol: self.data_set[symbol]["logo"] for symbol in
-                self.data_set.keys()}
+        data = self._get_endpoint("previous")
+        return {symbol: data[symbol]["previous"] for symbol in list(data)}
 
     @output_format(override='json')
     def get_price(self):
@@ -404,60 +413,48 @@ class StockReader(_IEXBase):
         float
             Stocks Price endpoint data
         """
-        return {symbol: self.data_set[symbol]["price"] for symbol in
-                self.data_set.keys()}
+        data = self._get_endpoint("price")
+        return {symbol: data[symbol]["price"] for symbol in list(data)}
 
+    # endpoint methods
     @output_format(override=None)
-    def get_delayed_quote(self):
+    def get_quote(self, **kwargs):
         """
-        Reference: https://iextrading.com/developer/docs/#delayed-quote
+        Reference: https://iextrading.com/developer/docs/#quote
 
         Returns
         -------
         dict or pandas.DataFrame
-            Stocks Delayed Quote endpoint data
+            Stocks Quote endpoint data
         """
-        return {symbol: self.data_set[symbol]["delayed-quote"] for symbol in
-                self.data_set.keys()}
+        data = self._get_endpoint("quote", kwargs)
+        return {symbol: data[symbol]["quote"] for symbol in list(data)}
 
     @output_format(override=None)
-    def get_effective_spread(self):
+    def get_relevant(self):
         """
-        Reference:  https://iextrading.com/developer/docs/#effective-spread
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks Effective Spread endpoint data
-        """
-        return {symbol: self.data_set[symbol]["effective-spread"] for symbol
-                in self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_volume_by_venue(self):
-        """
-        Reference:  https://iextrading.com/developer/docs/#volume-by-venue
-
-        Returns
-        -------
-        list or pandas.DataFrame
-            Stocks Volume by Venue endpoint data
-        """
-        return {symbol: self.data_set[symbol]["volume-by-venue"] for symbol
-                in self.data_set.keys()}
-
-    @output_format(override=None)
-    def get_ohlc(self):
-        """
-        Reference:  https://iextrading.com/developer/docs/#ohlc
+        Reference: https://iextrading.com/developer/docs/#relevant
 
         Returns
         -------
         dict or pandas.DataFrame
-            Stocks OHLC endpoint data
+            Stocks Relevant endpoint data
         """
-        return {symbol: self.data_set[symbol]["ohlc"] for symbol
-                in self.data_set.keys()}
+        data = self._get_endpoint("relevant")
+        return {symbol: data[symbol]["relevant"] for symbol in list(data)}
+
+    @output_format(override=None)
+    def get_splits(self, **kwargs):
+        """
+        Reference: https://iextrading.com/developer/docs/#splits
+
+        Returns
+        -------
+        list or pandas.DataFrame
+            Stocks Splits endpoint data
+        """
+        data = self._get_endpoint("splits", kwargs)
+        return {symbol: data[symbol]["splits"] for symbol in list(data)}
 
     def get_time_series(self):
         """
@@ -475,115 +472,131 @@ class StockReader(_IEXBase):
         """
         return self.get_chart()
 
+    @output_format(override=None)
+    def get_volume_by_venue(self):
+        """
+        Reference:  https://iextrading.com/developer/docs/#volume-by-venue
+
+        Returns
+        -------
+        list or pandas.DataFrame
+            Stocks Volume by Venue endpoint data
+        """
+        data = self._get_endpoint("volume-by-venue")
+        return {symbol: data[symbol]["volume-by-venue"] for symbol
+                in list(data)}
+
     # field methods
     @output_format(override='json')
     def get_company_name(self):
-        return {symbol: self.get_quote()[symbol]["companyName"]
+        return {symbol: self._get_endpoint('quote')[symbol]["companyName"]
                 if self.key == 'batch' else self.get_quote()['companyName']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_primary_exchange(self):
-        return {symbol: self.get_quote()[symbol]["primaryExchange"]
+        return {symbol: self._get_endpoint('quote')[symbol]["primaryExchange"]
                 if self.key == 'batch' else self.get_quote()['primaryExchange']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_sector(self):
-        return {symbol: self.get_quote()[symbol]["sector"]
+        return {symbol: self._get_endpoint('quote')[symbol]["sector"]
                 if self.key == 'batch' else self.get_quote()['sector']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_open(self):
-        return {symbol: self.get_quote()[symbol]["open"]
+        return {symbol: self._get_endpoint('quote')[symbol]["open"]
                 if self.key == 'batch' else self.get_quote()['open']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_close(self):
-        return {symbol: self.get_quote()[symbol]["close"]
+        return {symbol: self._get_endpoint('quote')[symbol]["close"]
                 if self.key == 'batch' else self.get_quote()['close']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_years_high(self):
-        return {symbol: self.get_quote()[symbol]["week52High"]
+        return {symbol: self._get_endpoint('quote')[symbol]["week52High"]
                 if self.key == 'batch' else self.get_quote()['week52High']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_years_low(self):
-        return {symbol: self.get_quote()[symbol]["week52Low"]
+        return {symbol: self._get_endpoint('quote')[symbol]["week52Low"]
                 if self.key == 'batch' else self.get_quote()['week52Low']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_ytd_change(self):
-        return {symbol: self.get_quote()[symbol]["ytdChange"]
+        return {symbol: self._get_endpoint('quote')[symbol]["ytdChange"]
                 if self.key == 'batch' else self.get_quote()['ytdChange']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_volume(self):
-        return {symbol: self.get_quote()[symbol]["latestVolume"]
+        return {symbol: self._get_endpoint('quote')[symbol]["latestVolume"]
                 if self.key == 'batch' else self.get_quote()['latestVolume']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_market_cap(self):
-        return {symbol: self.get_quote()[symbol]["marketCap"]
+        return {symbol: self._get_endpoint('quote')[symbol]["marketCap"]
                 if self.key == 'batch' else self.get_quote()['marketCap']
-                for symbol in self.data_set.keys()}
+                for symbol in self.symbols}
 
     @output_format(override='json')
     def get_beta(self):
-        return {symbol: self.get_key_stats()[symbol]["beta"]
+        return {symbol: self._get_endpoint("stats")[symbol]["beta"]
                 if self.key == 'batch' else
                 self.get_key_stats()['beta'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
     @output_format(override='json')
     def get_short_interest(self):
-        return {symbol: self.get_key_stats()[symbol]["shortInterest"]
+        return {symbol:
+                self._get_endpoint("stats")[symbol]["shortInterest"]
                 if self.key == 'batch' else
                 self.get_key_stats()['shortInterest'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
     @output_format(override='json')
     def get_short_ratio(self):
-        return {symbol: self.get_key_stats()[symbol]["shortRatio"]
+        return {symbol: self._get_endpoint("stats")[symbol]["shortRatio"]
                 if self.key == 'batch' else
                 self.get_key_stats()['shortRatio'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
     @output_format(override='json')
     def get_latest_eps(self):
-        return {symbol: self.get_key_stats()[symbol]["latestEPS"]
+        return {symbol: self._get_endpoint("stats")[symbol]["latestEPS"]
                 if self.key == 'batch' else
                 self.get_key_stats()['latestEPS'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
     @output_format(override='json')
     def get_shares_outstanding(self):
-        return {symbol: self.get_key_stats()[symbol]["sharesOutstanding"]
+        return {symbol:
+                self._get_endpoint("stats")[symbol]["sharesOutstanding"]
                 if self.key == 'batch' else
                 self.get_key_stats()['sharesOutstanding'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
     @output_format(override='json')
     def get_float(self):
-        return {symbol: self.get_key_stats()[symbol]["float"]
+        return {symbol: self._get_endpoint("stats")[symbol]["float"]
                 if self.key == 'batch' else
                 self.get_key_stats()['float'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
     @output_format(override='json')
     def get_eps_consensus(self):
-        return {symbol: self.get_key_stats()[symbol]["consensusEPS"]
+        return {symbol: self._get_endpoint("stats")[symbol]["consensusEPS"]
                 if self.key == 'batch' else
                 self.get_key_stats()['consensusEPS'] for symbol in
-                self.data_set.keys()}
+                self.symbols}
 
 
 class HistoricalReader(_IEXBase):

--- a/iexfinance/stock.py
+++ b/iexfinance/stock.py
@@ -196,10 +196,9 @@ class StockReader(_IEXBase):
                      for key in self.optional_params})
         if "filter_" in temp:
             if isinstance(temp["filter_"], list):
-                temp["filter"] = ",".join(temp["filter_"])
+                temp["filter"] = ",".join(temp.pop("filter_"))
             else:
-                temp["filter"] = temp["filter_"]
-            temp.pop("filter_")
+                temp["filter"] = temp.pop("filter_")
         if "range_" in temp:
             temp["range"] = temp.pop("range_")
         params = {k: str(v).lower() if v is True or v is False else str(v)

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import pytest
 import pandas as pd
+from pandas.util.testing import assert_index_equal
 
 from iexfinance import get_historical_data
 from iexfinance import Stock
@@ -45,6 +46,17 @@ class TestShareDefault(object):
         data = self.cshare.get_all()
         assert len(data) == 20
 
+    def test_get_endpoints(self):
+        data = self.cshare.get_endpoints(["price"])
+        assert list(data) == ["price"]
+
+    def test_get_endpoints_bad_endpoint(self):
+        with pytest.raises(IEXEndpointError):
+            self.cshare.get_endpoints(["BAD ENDPOINT", "quote"])
+
+        with pytest.raises(IEXEndpointError):
+            self.cshare.get_endpoints("BAD ENDPOINT")
+
     def test_get_book_format(self):
         data = self.cshare.get_book()
         assert isinstance(data, dict)
@@ -62,7 +74,7 @@ class TestShareDefault(object):
     def test_get_chart_params(self):
         data = self.cshare.get_chart()
         # Test chart ranges
-        data2 = self.cshare.get_chart(range='1y')
+        data2 = self.cshare.get_chart(range_='1y')
         assert 15 < len(data) < 35
         assert 240 < len(data2) < 260
 
@@ -70,14 +82,14 @@ class TestShareDefault(object):
         data4 = self.cshare.get_chart(chartSimplify=True)[0]
         assert "simplifyFactor" in list(data4)
 
-        data5 = self.cshare.get_chart(Range='1y', chartInterval=5)
+        data5 = self.cshare.get_chart(range_='1y', chartInterval=5)
         assert 45 < len(data5) < 55
 
     @pytest.mark.xfail(reason="This test only runs correctly between 00:00 and"
                        "09:30 EST")
     def test_get_chart_reset(self):
         # Test chartReset
-        data3 = self.cshare.get_chart(Range='1d', chartReset=True)
+        data3 = self.cshare.get_chart(range_='1d', chartReset=True)
         assert data3 == []
 
     def test_get_company_format(self):
@@ -103,8 +115,8 @@ class TestShareDefault(object):
 
     def test_get_dividends_params(self):
         data = self.cshare.get_dividends()
-        data2 = self.cshare.get_dividends(Range='2y')
-        data3 = self.cshare.get_dividends(Range='5y')
+        data2 = self.cshare.get_dividends(range_='2y')
+        data3 = self.cshare.get_dividends(range_='5y')
         assert len(data) < len(data2) < len(data3)
 
     def test_get_earnings_format(self):
@@ -186,7 +198,7 @@ class TestShareDefault(object):
         assert isinstance(data, float)
 
         data2 = self.cshare2.get_price()
-        assert isinstance(data2, float)
+        assert isinstance(data2, pd.DataFrame)
 
     def test_get_quote_format(self):
         data = self.cshare.get_quote()
@@ -212,12 +224,12 @@ class TestShareDefault(object):
         data = self.cshare3.get_splits()
         assert isinstance(data, list)
 
-        data2 = self.cshare3.get_splits(Range="1y")
+        data2 = self.cshare3.get_splits(range_="1y")
         assert isinstance(data2, list)
 
     def test_get_splits_params(self):
-        data = self.cshare3.get_splits(Range="2y")
-        data2 = self.cshare3.get_splits(Range="5y")
+        data = self.cshare3.get_splits(range_="2y")
+        data2 = self.cshare3.get_splits(range_="5y")
         assert len(data2) > len(data)
 
     def test_get_time_series(self):
@@ -244,6 +256,17 @@ class TestBatchDefault(object):
         with pytest.raises(IEXSymbolError):
             a = Stock(["TSLA", "BAD SYMBOL", "BAD SYMBOL"])
             a.get_price()
+
+    def test_get_endpoints(self):
+        data = self.cbatch.get_endpoints(["price"])["AAPL"]
+        assert list(data) == ["price"]
+
+    def test_get_endpoints_bad_endpoint(self):
+        with pytest.raises(IEXEndpointError):
+            self.cbatch.get_endpoints(["BAD ENDPOINT", "quote"])
+
+        with pytest.raises(IEXEndpointError):
+            self.cbatch.get_endpoints("BAD ENDPOINT")
 
     def test_get_all(self):
         data = self.cbatch.get_all()
@@ -273,8 +296,8 @@ class TestBatchDefault(object):
 
     def test_get_chart_params(self):
         data = self.cbatch.get_chart()["AAPL"]
-        # Test chart ranges
-        data2 = self.cbatch.get_chart(range='1y')["AAPL"]
+        # Test chart range_s
+        data2 = self.cbatch.get_chart(range_='1y')["AAPL"]
         assert 15 < len(data) < 35
         assert 240 < len(data2) < 260
 
@@ -282,13 +305,13 @@ class TestBatchDefault(object):
         data4 = self.cbatch.get_chart(chartSimplify=True)["AAPL"][0]
         assert "simplifyFactor" in list(data4)
 
-        data5 = self.cbatch.get_chart(Range='1y', chartInterval=5)["AAPL"]
+        data5 = self.cbatch.get_chart(range_='1y', chartInterval=5)["AAPL"]
         assert 45 < len(data5) < 55
 
     @pytest.mark.xfail(reason="This test only works overnight")
     def test_get_chart_reset(self):
         # Test chartReset
-        data = self.cbatch.get_chart(Range='1d', chartReset=True)
+        data = self.cbatch.get_chart(range_='1d', chartReset=True)
         assert data == []
 
     def test_get_company_format(self):
@@ -314,8 +337,8 @@ class TestBatchDefault(object):
 
     def test_get_dividends_params(self):
         data = self.cbatch.get_dividends()["AAPL"]
-        data2 = self.cbatch.get_dividends(Range='2y')["AAPL"]
-        data3 = self.cbatch.get_dividends(Range='5y')["AAPL"]
+        data2 = self.cbatch.get_dividends(range_='2y')["AAPL"]
+        data3 = self.cbatch.get_dividends(range_='5y')["AAPL"]
         assert len(data) < len(data2) < len(data3)
 
     def test_get_earnings_format(self):
@@ -390,7 +413,7 @@ class TestBatchDefault(object):
         assert isinstance(data, dict)
 
         data2 = self.cbatch2.get_price()
-        assert isinstance(data2["AAPL"], float)
+        assert isinstance(data2, pd.DataFrame)
 
     def test_get_quote_format(self):
         data = self.cbatch.get_quote()
@@ -418,8 +441,8 @@ class TestBatchDefault(object):
         assert isinstance(data2, pd.DataFrame)
 
     def test_get_splits_params(self):
-        data = self.cbatch3.get_splits(Range="2y")["SVXY"]
-        data2 = self.cbatch3.get_splits(Range="5y")["SVXY"]
+        data = self.cbatch3.get_splits(range_="2y")["SVXY"]
+        data2 = self.cbatch3.get_splits(range_="5y")["SVXY"]
         assert len(data2) > len(data)
 
     def test_time_series(self):
@@ -440,6 +463,327 @@ class TestBatchDefault(object):
 
         with pytest.raises(IEXEndpointError):
             self.cbatch.get_endpoints("BADENDPOINT")
+
+
+class TestFieldMethodsShare(object):
+
+    def setup_class(self):
+        self.share = Stock("AAPL")
+        self.share2 = Stock("AAPL", output_format='pandas')
+
+    def test_get_company_name(self):
+        data = self.share.get_company_name()
+        assert isinstance(data, str)
+        assert data == "Apple Inc."
+
+        data2 = self.share2.get_company_name()
+        assert isinstance(data2, pd.DataFrame)
+
+    def test_get_primary_exchange(self):
+        data = self.share.get_primary_exchange()
+        assert isinstance(data, str)
+        assert data == "Nasdaq Global Select"
+
+        data2 = self.share2.get_primary_exchange()
+        assert isinstance(data2, pd.DataFrame)
+
+    def test_get_sector(self):
+        data = self.share.get_sector()
+        assert isinstance(data, str)
+        assert data == "Technology"
+
+        data2 = self.share2.get_sector()
+        assert isinstance(data2, pd.DataFrame)
+
+    def test_get_open(self):
+        data = self.share.get_open()
+        assert isinstance(data, float)
+        assert data > 0
+
+        data2 = self.share2.get_open()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_close(self):
+        data = self.share.get_close()
+        assert isinstance(data, float)
+        assert data > 0
+
+        data2 = self.share2.get_close()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_years_high(self):
+        data = self.share.get_years_high()
+        assert isinstance(data, float)
+        assert data > 0
+
+        data2 = self.share2.get_years_high()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_years_low(self):
+        data = self.share.get_years_low()
+        assert isinstance(data, float)
+        assert data > 0
+
+        data2 = self.share2.get_years_low()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_ytd_change(self):
+        data = self.share.get_ytd_change()
+        assert isinstance(data, float)
+
+        data2 = self.share2.get_ytd_change()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_volume(self):
+        data = self.share.get_volume()
+        assert isinstance(data, int)
+        assert data > 1000
+
+        data2 = self.share2.get_volume()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_market_cap(self):
+        data = self.share.get_market_cap()
+        assert isinstance(data, int)
+
+        data2 = self.share2.get_market_cap()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_beta(self):
+        data = self.share.get_beta()
+        assert isinstance(data, float)
+
+        data2 = self.share2.get_beta()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_short_interest(self):
+        data = self.share.get_short_interest()
+        assert isinstance(data, int)
+
+        data2 = self.share2.get_short_interest()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_short_ratio(self):
+        data = self.share.get_short_ratio()
+        assert isinstance(data, float)
+
+        data2 = self.share2.get_short_ratio()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_latest_eps(self):
+        data = self.share.get_latest_eps()
+        assert isinstance(data, float)
+
+        data2 = self.share2.get_latest_eps()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_shares_outstanding(self):
+        data = self.share.get_shares_outstanding()
+        assert isinstance(data, int)
+
+        data2 = self.share2.get_shares_outstanding()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_float(self):
+        data = self.share.get_float()
+        assert isinstance(data, int)
+
+        data2 = self.share2.get_float()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_eps_consensus(self):
+        data = self.share.get_eps_consensus()
+        assert isinstance(data, float)
+
+        data2 = self.share2.get_eps_consensus()
+        assert isinstance(data2, pd.DataFrame)
+        assert data2.loc["AAPL"].dtype == "float64"
+
+
+class TestFieldMethodsBatch(object):
+
+    def setup_class(self):
+        self.batch = Stock(["AAPL", "TSLA"])
+        self.batch2 = Stock(["AAPL", "TSLA"], output_format='pandas')
+
+    def test_get_company_name(self):
+        data = self.batch.get_company_name()
+        assert isinstance(data, dict)
+        assert data["AAPL"] == "Apple Inc."
+
+        data2 = self.batch2.get_company_name()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+
+    def test_get_primary_exchange(self):
+        data = self.batch.get_primary_exchange()
+        assert isinstance(data, dict)
+        assert data["AAPL"] == "Nasdaq Global Select"
+
+        data2 = self.batch2.get_primary_exchange()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+
+    def test_get_sector(self):
+        data = self.batch.get_sector()
+        assert isinstance(data, dict)
+        assert data["AAPL"] == "Technology"
+
+        data2 = self.batch2.get_sector()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+
+    def test_get_open(self):
+        data = self.batch.get_open()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 0
+
+        data2 = self.batch2.get_open()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_close(self):
+        data = self.batch.get_close()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 0
+
+        data2 = self.batch2.get_close()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_years_high(self):
+        data = self.batch.get_years_high()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 0
+
+        data2 = self.batch2.get_years_high()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_years_low(self):
+        data = self.batch.get_years_low()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 0
+
+        data2 = self.batch2.get_years_low()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_ytd_change(self):
+        data = self.batch.get_ytd_change()
+        assert isinstance(data, dict)
+
+        data2 = self.batch2.get_ytd_change()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_volume(self):
+        data = self.batch.get_volume()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 50000
+
+        data2 = self.batch2.get_volume()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_market_cap(self):
+        data = self.batch.get_market_cap()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 1000000
+
+        data2 = self.batch2.get_market_cap()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_beta(self):
+        data = self.batch.get_beta()
+        assert isinstance(data, dict)
+        assert isinstance(data["AAPL"], float)
+
+        data2 = self.batch2.get_beta()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_short_interest(self):
+        data = self.batch.get_short_interest()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 50000
+
+        data2 = self.batch2.get_short_interest()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_short_ratio(self):
+        data = self.batch.get_short_ratio()
+        assert isinstance(data, dict)
+        assert isinstance(data["AAPL"], float)
+
+        data2 = self.batch2.get_short_ratio()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_latest_eps(self):
+        data = self.batch.get_latest_eps()
+        assert isinstance(data, dict)
+        assert isinstance(data["AAPL"], float)
+
+        data2 = self.batch2.get_latest_eps()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
+
+    def test_get_shares_outstanding(self):
+        data = self.batch.get_shares_outstanding()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 100000
+
+        data2 = self.batch2.get_shares_outstanding()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_float(self):
+        data = self.batch.get_float()
+        assert isinstance(data, dict)
+        assert data["AAPL"] > 1000000
+
+        data2 = self.batch2.get_float()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "int64"
+
+    def test_get_eps_consensus(self):
+        data = self.batch.get_eps_consensus()
+        assert isinstance(data, dict)
+        assert isinstance(data["AAPL"], float)
+
+        data2 = self.batch2.get_eps_consensus()
+        assert isinstance(data2, pd.DataFrame)
+        assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
+        assert data2.loc["AAPL"].dtype == "float64"
 
 
 class TestHistorical(object):

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -8,6 +8,10 @@ from iexfinance import get_historical_data
 from iexfinance import Stock
 from iexfinance.utils.exceptions import IEXSymbolError, IEXEndpointError
 
+import sys
+
+_SYS_VERSION_MAJOR = sys.version_info.major
+
 
 class TestBase(object):
 
@@ -473,7 +477,11 @@ class TestFieldMethodsShare(object):
 
     def test_get_company_name(self):
         data = self.share.get_company_name()
-        assert isinstance(data, str)
+        print(type(data))
+        if _SYS_VERSION_MAJOR < 3:
+            assert isinstance(data, unicode)
+        else:
+            assert isinstance(data, str)
         assert data == "Apple Inc."
 
         data2 = self.share2.get_company_name()
@@ -481,7 +489,10 @@ class TestFieldMethodsShare(object):
 
     def test_get_primary_exchange(self):
         data = self.share.get_primary_exchange()
-        assert isinstance(data, str)
+        if _SYS_VERSION_MAJOR < 3:
+            assert isinstance(data, unicode)
+        else:
+            assert isinstance(data, str)
         assert data == "Nasdaq Global Select"
 
         data2 = self.share2.get_primary_exchange()
@@ -489,7 +500,10 @@ class TestFieldMethodsShare(object):
 
     def test_get_sector(self):
         data = self.share.get_sector()
-        assert isinstance(data, str)
+        if _SYS_VERSION_MAJOR < 3:
+            assert isinstance(data, unicode)
+        else:
+            assert isinstance(data, str)
         assert data == "Technology"
 
         data2 = self.share2.get_sector()


### PR DESCRIPTION
Fixes #15, #23, #24, #25, #27, #28. 

- Stock endpoint requests are now made on a per-call basis. All endpoints are not downloaded at instantiation.
- ``refresh`` has been removed
- ``get_select_endpoints`` is now ``get_endpoints``
- ``get_select_datapoints`` has been removed
- Parameters to individual endpoints (such as ``displayPercent`` for Quote) are now passed to the endpoint methods as keyword arguments, rather than the Stock method at instantiation:

```python
from iexfinance import Stock

aapl = Stock("AAPL")
aapl.get_quote(displayPercent=True)
```

- Field methods have been rebuilt. Now support DataFrame output formatting.
- Cleans docs for RLS 0.3.0