### PR TITLE
Financial decimal parsing

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,6 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 sys.path.insert(0, os.path.abspath('../..'))
 
-import requests_cache
 #
 # iexfinance documentation build configuration file, created by
 # sphinx-quickstart on Sat Jan 27 14:14:10 2018.

--- a/iexfinance/base.py
+++ b/iexfinance/base.py
@@ -45,13 +45,14 @@ class _IEXBase(object):
         self.retry_count = kwargs.pop("retry_count", 3)
         self.pause = kwargs.pop("pause", 0.001)
         self.session = _init_session(kwargs.pop("session", None))
+        self.json_parse_int = kwargs.pop("json_parse_int", None)
+        self.json_parse_float = kwargs.pop("json_parse_float", None)
 
     @property
     def params(self):
         return {}
 
-    @staticmethod
-    def _validate_response(response):
+    def _validate_response(self, response):
         """ Ensures response from IEX server is valid.
 
         Parameters
@@ -74,7 +75,9 @@ class _IEXBase(object):
         """
         if response.text == "Unknown symbol":
             raise IEXQueryError()
-        json_response = response.json()
+        json_response = response.json(
+            parse_int=self.json_parse_int, 
+            parse_float=self.json_parse_float)
         if "Error Message" in json_response:
             raise IEXQueryError()
         return json_response

--- a/iexfinance/base.py
+++ b/iexfinance/base.py
@@ -76,7 +76,7 @@ class _IEXBase(object):
         if response.text == "Unknown symbol":
             raise IEXQueryError()
         json_response = response.json(
-            parse_int=self.json_parse_int, 
+            parse_int=self.json_parse_int,
             parse_float=self.json_parse_float)
         if "Error Message" in json_response:
             raise IEXQueryError()

--- a/iexfinance/stats.py
+++ b/iexfinance/stats.py
@@ -144,7 +144,7 @@ class DailySummaryReader(Stats):
         self._validate_params()
         super(DailySummaryReader, self).__init__(output_format=output_format,
                                                  **kwargs)
-        
+
     def _validate_params(self):
         if self.last is not None:
             if not isinstance(self.last, int) or not (0 < self.last < 90):
@@ -159,7 +159,7 @@ class DailySummaryReader(Stats):
 
     def _validate_response(self, response):
         return response.json(
-            parse_int=self.json_parse_int, 
+            parse_int=self.json_parse_int,
             parse_float=self.json_parse_float)
 
     @property

--- a/iexfinance/stats.py
+++ b/iexfinance/stats.py
@@ -139,10 +139,12 @@ class DailySummaryReader(Stats):
         self.last = last
         self.start = start
         self.end = end
+        self.json_parse_int = kwargs.pop("json_parse_int", None)
+        self.json_parse_float = kwargs.pop("json_parse_float", None)
         self._validate_params()
         super(DailySummaryReader, self).__init__(output_format=output_format,
                                                  **kwargs)
-
+        
     def _validate_params(self):
         if self.last is not None:
             if not isinstance(self.last, int) or not (0 < self.last < 90):
@@ -155,9 +157,10 @@ class DailySummaryReader(Stats):
         raise ValueError("Please enter a date range or number of days for "
                          "retrieval period.")
 
-    @staticmethod
-    def _validate_response(response):
-        return response.json()
+    def _validate_response(self, response):
+        return response.json(
+            parse_int=self.json_parse_int, 
+            parse_float=self.json_parse_float)
 
     @property
     def url(self):

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -4,6 +4,8 @@ import pytest
 import pandas as pd
 from pandas.util.testing import assert_index_equal
 
+from decimal import Decimal
+
 from iexfinance import get_historical_data
 from iexfinance import Stock
 from iexfinance.utils.exceptions import IEXSymbolError, IEXEndpointError
@@ -41,6 +43,7 @@ class TestShareDefault(object):
         self.cshare = Stock("aapl")
         self.cshare2 = Stock("aapl", output_format='pandas')
         self.cshare3 = Stock("svxy")
+        self.cshare4 = Stock("aapl", json_parse_int=Decimal, json_parse_float=Decimal)
 
     def test_invalid_symbol(self):
         data = Stock("BAD SYMBOL")
@@ -209,6 +212,9 @@ class TestShareDefault(object):
         data2 = self.cshare2.get_price()
         assert isinstance(data2, pd.DataFrame)
 
+        data4 = self.cshare4.get_price()
+        assert isinstance(data4, Decimal)
+
     def test_get_quote_format(self):
         data = self.cshare.get_quote()
         assert isinstance(data, dict)
@@ -258,6 +264,10 @@ class TestShareDefault(object):
         data = self.cshare.get_quote(filter_='ytdChange')
         assert isinstance(data, dict)
         assert isinstance(data["ytdChange"], float)
+
+        data4 = self.cshare4.get_quote(filter_='ytdChange')
+        assert isinstance(data4, dict)
+        assert isinstance(data4["ytdChange"], Decimal)
 
 
 class TestBatchDefault(object):
@@ -485,6 +495,7 @@ class TestFieldMethodsShare(object):
     def setup_class(self):
         self.share = Stock("AAPL")
         self.share2 = Stock("AAPL", output_format='pandas')
+        self.share4 = Stock("AAPL", json_parse_int=Decimal, json_parse_float=Decimal)
 
     def test_get_company_name(self):
         data = self.share.get_company_name()
@@ -522,6 +533,10 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.share4.get_open()
+        assert isinstance(data4, Decimal)
+        assert data4 > 0
+
     def test_get_close(self):
         data = self.share.get_close()
         assert isinstance(data, float)
@@ -530,6 +545,10 @@ class TestFieldMethodsShare(object):
         data2 = self.share2.get_close()
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
+
+        data4 = self.share4.get_close()
+        assert isinstance(data4, Decimal)
+        assert data4 > 0
 
     def test_get_years_high(self):
         data = self.share.get_years_high()
@@ -540,6 +559,10 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.share4.get_years_high()
+        assert isinstance(data4, Decimal)
+        assert data4 > 0
+
     def test_get_years_low(self):
         data = self.share.get_years_low()
         assert isinstance(data, float)
@@ -549,6 +572,10 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.share4.get_years_low()
+        assert isinstance(data4, Decimal)
+        assert data4 > 0
+
     def test_get_ytd_change(self):
         data = self.share.get_ytd_change()
         assert isinstance(data, float)
@@ -556,6 +583,9 @@ class TestFieldMethodsShare(object):
         data2 = self.share2.get_ytd_change()
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
+
+        data4 = self.share4.get_ytd_change()
+        assert isinstance(data4, Decimal)
 
     def test_get_volume(self):
         data = self.share.get_volume()
@@ -566,6 +596,11 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "int64"
 
+        data4 = self.share4.get_volume()
+        assert isinstance(data4, Decimal)
+        assert data4 > 1000
+
+
     def test_get_market_cap(self):
         data = self.share.get_market_cap()
         assert isinstance(data, int)
@@ -573,6 +608,9 @@ class TestFieldMethodsShare(object):
         data2 = self.share2.get_market_cap()
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "int64"
+
+        data4 = self.share4.get_market_cap()
+        assert isinstance(data4, Decimal)
 
     def test_get_beta(self):
         data = self.share.get_beta()
@@ -582,6 +620,9 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.share4.get_beta()
+        assert isinstance(data4, Decimal)
+
     def test_get_short_interest(self):
         data = self.share.get_short_interest()
         assert isinstance(data, int)
@@ -589,6 +630,9 @@ class TestFieldMethodsShare(object):
         data2 = self.share2.get_short_interest()
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "int64"
+
+        data4 = self.share4.get_short_interest()
+        assert isinstance(data4, Decimal)
 
     def test_get_short_ratio(self):
         data = self.share.get_short_ratio()
@@ -598,6 +642,9 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.share4.get_short_ratio()
+        assert isinstance(data4, Decimal)
+
     def test_get_latest_eps(self):
         data = self.share.get_latest_eps()
         assert isinstance(data, float)
@@ -605,6 +652,9 @@ class TestFieldMethodsShare(object):
         data2 = self.share2.get_latest_eps()
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
+
+        data4 = self.share4.get_latest_eps()
+        assert isinstance(data4, Decimal)
 
     def test_get_shares_outstanding(self):
         data = self.share.get_shares_outstanding()
@@ -614,6 +664,9 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "int64"
 
+        data4 = self.share4.get_shares_outstanding()
+        assert isinstance(data4, Decimal)
+
     def test_get_float(self):
         data = self.share.get_float()
         assert isinstance(data, int)
@@ -621,6 +674,9 @@ class TestFieldMethodsShare(object):
         data2 = self.share2.get_float()
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "int64"
+
+        data4 = self.share4.get_float()
+        assert isinstance(data4, Decimal)
 
     def test_get_eps_consensus(self):
         data = self.share.get_eps_consensus()
@@ -630,12 +686,15 @@ class TestFieldMethodsShare(object):
         assert isinstance(data2, pd.DataFrame)
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.share4.get_eps_consensus()
+        assert isinstance(data4, Decimal)
 
 class TestFieldMethodsBatch(object):
 
     def setup_class(self):
         self.batch = Stock(["AAPL", "TSLA"])
         self.batch2 = Stock(["AAPL", "TSLA"], output_format='pandas')
+        self.batch4 = Stock(["AAPL", "TSLA"], json_parse_int=Decimal, json_parse_float=Decimal)
 
     def test_get_company_name(self):
         data = self.batch.get_company_name()
@@ -743,6 +802,10 @@ class TestFieldMethodsBatch(object):
         assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.batch4.get_beta()
+        assert isinstance(data4, dict)
+        assert isinstance(data4["AAPL"], Decimal)
+
     def test_get_short_interest(self):
         data = self.batch.get_short_interest()
         assert isinstance(data, dict)
@@ -763,6 +826,10 @@ class TestFieldMethodsBatch(object):
         assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
         assert data2.loc["AAPL"].dtype == "float64"
 
+        data4 = self.batch4.get_short_ratio()
+        assert isinstance(data4, dict)
+        assert isinstance(data4["AAPL"], Decimal)
+
     def test_get_latest_eps(self):
         data = self.batch.get_latest_eps()
         assert isinstance(data, dict)
@@ -772,6 +839,10 @@ class TestFieldMethodsBatch(object):
         assert isinstance(data2, pd.DataFrame)
         assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
         assert data2.loc["AAPL"].dtype == "float64"
+
+        data4 = self.batch4.get_latest_eps()
+        assert isinstance(data4, dict)
+        assert isinstance(data4["AAPL"], Decimal)
 
     def test_get_shares_outstanding(self):
         data = self.batch.get_shares_outstanding()
@@ -802,6 +873,10 @@ class TestFieldMethodsBatch(object):
         assert isinstance(data2, pd.DataFrame)
         assert_index_equal(data2.index, pd.Index(self.batch2.symbols))
         assert data2.loc["AAPL"].dtype == "float64"
+
+        data4 = self.batch4.get_eps_consensus()
+        assert isinstance(data4, dict)
+        assert isinstance(data4["AAPL"], Decimal)
 
 
 class TestHistorical(object):

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -10,14 +10,7 @@ from iexfinance import get_historical_data
 from iexfinance import Stock
 from iexfinance.utils.exceptions import IEXSymbolError, IEXEndpointError
 
-import sys
-
-PY3 = sys.version_info.major == 3
-
-if PY3:
-    string_types = (str, )
-else:
-    string_types = (str, unicode)
+import six
 
 
 class TestBase(object):
@@ -505,7 +498,7 @@ class TestFieldMethodsShare(object):
         data = self.share.get_company_name()
         print(type(data))
 
-        assert isinstance(data, string_types)
+        assert isinstance(data, six.string_types)
         assert data == "Apple Inc."
 
         data2 = self.share2.get_company_name()
@@ -513,7 +506,7 @@ class TestFieldMethodsShare(object):
 
     def test_get_primary_exchange(self):
         data = self.share.get_primary_exchange()
-        assert isinstance(data, string_types)
+        assert isinstance(data, six.string_types)
         assert data == "Nasdaq Global Select"
 
         data2 = self.share2.get_primary_exchange()
@@ -522,7 +515,7 @@ class TestFieldMethodsShare(object):
     def test_get_sector(self):
         data = self.share.get_sector()
 
-        assert isinstance(data, string_types)
+        assert isinstance(data, six.string_types)
         assert data == "Technology"
 
         data2 = self.share2.get_sector()

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -43,7 +43,9 @@ class TestShareDefault(object):
         self.cshare = Stock("aapl")
         self.cshare2 = Stock("aapl", output_format='pandas')
         self.cshare3 = Stock("svxy")
-        self.cshare4 = Stock("aapl", json_parse_int=Decimal, json_parse_float=Decimal)
+        self.cshare4 = Stock("aapl",
+                             json_parse_int=Decimal,
+                             json_parse_float=Decimal)
 
     def test_invalid_symbol(self):
         data = Stock("BAD SYMBOL")
@@ -495,7 +497,9 @@ class TestFieldMethodsShare(object):
     def setup_class(self):
         self.share = Stock("AAPL")
         self.share2 = Stock("AAPL", output_format='pandas')
-        self.share4 = Stock("AAPL", json_parse_int=Decimal, json_parse_float=Decimal)
+        self.share4 = Stock("AAPL",
+                            json_parse_int=Decimal,
+                            json_parse_float=Decimal)
 
     def test_get_company_name(self):
         data = self.share.get_company_name()
@@ -600,7 +604,6 @@ class TestFieldMethodsShare(object):
         assert isinstance(data4, Decimal)
         assert data4 > 1000
 
-
     def test_get_market_cap(self):
         data = self.share.get_market_cap()
         assert isinstance(data, int)
@@ -689,12 +692,15 @@ class TestFieldMethodsShare(object):
         data4 = self.share4.get_eps_consensus()
         assert isinstance(data4, Decimal)
 
+
 class TestFieldMethodsBatch(object):
 
     def setup_class(self):
         self.batch = Stock(["AAPL", "TSLA"])
         self.batch2 = Stock(["AAPL", "TSLA"], output_format='pandas')
-        self.batch4 = Stock(["AAPL", "TSLA"], json_parse_int=Decimal, json_parse_float=Decimal)
+        self.batch4 = Stock(["AAPL", "TSLA"],
+                            json_parse_int=Decimal,
+                            json_parse_float=Decimal)
 
     def test_get_company_name(self):
         data = self.batch.get_company_name()


### PR DESCRIPTION
Allow correct financial calculation using the Decimal data type by letting the JSON parser turn float-like values into Decimal.
    This behaviour can be specified during class creation using the kwarg 'json_parse_int' and 'json_parse_float' to parse INTs and FLOATs into Decimal respectivelly.
    
    Example:

        from decimal import Decimal    
        Stock('aapl', 
                json_parse_int=Decimal, 
                json_parse_float=Decimal
            ).get_dividends(range='1y')
