### PR TITLE
Fix KeyError exception when there is no earnings or financials data on a ticker.

### DIFF
--- a/docs/source/whatsnew/v0.3.4.txt
+++ b/docs/source/whatsnew/v0.3.4.txt
@@ -1,0 +1,11 @@
+.. _whatsnew_034:
+
+
+v0.3.4 
+-------------------------
+
+Bug Fixes
+~~~~~~~~~
+
+-  Fix KeyError exception when there is no earnings or financials data on a ticker.
+   `User@SHA <reixd@644e32e03fa52ce4efafe4c2695489b5bd645b96>`__

--- a/iexfinance/stock.py
+++ b/iexfinance/stock.py
@@ -359,7 +359,7 @@ class StockReader(_IEXBase):
             Stocks Earnings endpoint data
         """
         data = self._get_endpoint("earnings", kwargs)
-        return {symbol: data[symbol]["earnings"]["earnings"]
+        return {symbol: data[symbol]["earnings"].get("earnings", [])
                 for symbol in list(data)}
 
     @output_format(override=None)
@@ -387,7 +387,7 @@ class StockReader(_IEXBase):
             Stocks Financials endpoint data
         """
         data = self._get_endpoint("financials", kwargs)
-        return {symbol: data[symbol]["financials"]["financials"]
+        return {symbol: data[symbol]["financials"].get("financials", [])
                 for symbol in list(data)}
 
     @output_format(override=None)

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -41,6 +41,7 @@ class TestShareDefault(object):
         self.cshare4 = Stock("aapl",
                              json_parse_int=Decimal,
                              json_parse_float=Decimal)
+        self.cshare5 = Stock("gig^")
 
     def test_invalid_symbol(self):
         data = Stock("BAD SYMBOL")
@@ -135,6 +136,11 @@ class TestShareDefault(object):
         data2 = self.cshare2.get_earnings()
         assert isinstance(data2, pd.DataFrame)
 
+        # Even if there is no earnings information,
+        # requite a list object
+        data = self.cshare5.get_earnings()
+        assert isinstance(data, list)
+
     def test_get_effective_spread_format(self):
         data = self.cshare.get_effective_spread()
         assert isinstance(data, list)
@@ -148,6 +154,11 @@ class TestShareDefault(object):
 
         data2 = self.cshare2.get_financials()
         assert isinstance(data2, pd.DataFrame)
+
+        # Even if there is no earnings information,
+        # requite a list object
+        data = self.cshare5.get_financials()
+        assert isinstance(data, list)
 
     def test_get_key_stats_format(self):
         data = self.cshare.get_key_stats()


### PR DESCRIPTION
Deliver an empty list to denote the missing iterable data.

- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt