### PR TITLE
Repair exceptions and test cases 

### DIFF
--- a/docs/source/whatsnew/v0.3.3.txt
+++ b/docs/source/whatsnew/v0.3.3.txt
@@ -1,4 +1,4 @@
-.. _whatsnew_032:
+.. _whatsnew_033:
 
 
 v0.3.3 (April 21, 2018)

--- a/docs/source/whatsnew/v0.3.4.txt
+++ b/docs/source/whatsnew/v0.3.4.txt
@@ -9,5 +9,6 @@ This is a minor release from 0.3.4.
 Bug Fixes
 ~~~~~~~~~
 
--  Fix KeyError exception when there is no earnings or financials data on a ticker. (Thank you reixd)
+- Removes dividend-issuing tickers from historical price tests `GH61 <https://github.com/addisonlynch/iexfinance/pull/61>`__
+- Fix KeyError exception when there is no earnings or financials data on a ticker. (Thank you reixd)
 `GH60 <https://github.com/addisonlynch/iexfinance/pull/60>`__

--- a/docs/source/whatsnew/v0.3.4.txt
+++ b/docs/source/whatsnew/v0.3.4.txt
@@ -1,0 +1,13 @@
+.. _whatsnew_034:
+
+
+v0.3.4 (TBA)
+-----------------------
+
+This is a minor release from 0.3.4.
+
+Bug Fixes
+~~~~~~~~~
+
+-  Fix KeyError exception when there is no earnings or financials data on a ticker. (Thank you reixd)
+`GH60 <https://github.com/addisonlynch/iexfinance/pull/60>`__

--- a/iexfinance/stock.py
+++ b/iexfinance/stock.py
@@ -359,7 +359,7 @@ class StockReader(_IEXBase):
             Stocks Earnings endpoint data
         """
         data = self._get_endpoint("earnings", kwargs)
-        return {symbol: data[symbol]["earnings"]["earnings"]
+        return {symbol: data[symbol]["earnings"].get("earnings", [])
                 for symbol in list(data)}
 
     @output_format(override=None)
@@ -387,7 +387,7 @@ class StockReader(_IEXBase):
             Stocks Financials endpoint data
         """
         data = self._get_endpoint("financials", kwargs)
-        return {symbol: data[symbol]["financials"]["financials"]
+        return {symbol: data[symbol]["financials"].get("financials", [])
                 for symbol in list(data)}
 
     @output_format(override=None)

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -41,6 +41,7 @@ class TestShareDefault(object):
         self.cshare4 = Stock("aapl",
                              json_parse_int=Decimal,
                              json_parse_float=Decimal)
+        self.cshare5 = Stock("gig^")
 
     def test_invalid_symbol(self):
         data = Stock("BAD SYMBOL")
@@ -135,6 +136,10 @@ class TestShareDefault(object):
         data2 = self.cshare2.get_earnings()
         assert isinstance(data2, pd.DataFrame)
 
+        # Ensure empty list is returned for symbol with no earnings
+        data3 = self.cshare5.get_earnings()
+        assert isinstance(data3, list)
+
     def test_get_effective_spread_format(self):
         data = self.cshare.get_effective_spread()
         assert isinstance(data, list)
@@ -148,6 +153,10 @@ class TestShareDefault(object):
 
         data2 = self.cshare2.get_financials()
         assert isinstance(data2, pd.DataFrame)
+
+        # Ensure empty list is returned even when ticker has no financials
+        data3 = self.cshare5.get_financials()
+        assert isinstance(data3, list)
 
     def test_get_key_stats_format(self):
         data = self.cshare.get_key_stats()

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -897,56 +897,56 @@ class TestHistorical(object):
 
     def test_single_historical_json(self):
 
-        f = get_historical_data("AAPL", self.good_start, self.good_end)
+        f = get_historical_data("AMZN", self.good_start, self.good_end)
         assert isinstance(f, dict)
-        assert len(f["AAPL"]) == 73
+        assert len(f["AMZN"]) == 73
 
-        expected1 = f["AAPL"]["2017-02-09"]
-        assert expected1["close"] == pytest.approx(132.42, 3)
-        assert expected1["high"] == pytest.approx(132.445, 3)
+        expected1 = f["AMZN"]["2017-02-09"]
+        assert expected1["close"] == pytest.approx(821.36, 3)
+        assert expected1["high"] == pytest.approx(825.0, 3)
 
-        expected2 = f["AAPL"]["2017-05-24"]
-        assert expected2["close"] == pytest.approx(153.34, 3)
-        assert expected2["high"] == pytest.approx(154.17, 3)
+        expected2 = f["AMZN"]["2017-05-24"]
+        assert expected2["close"] == pytest.approx(980.35, 3)
+        assert expected2["high"] == pytest.approx(981.0, 3)
 
     def test_single_historical_pandas(self):
 
-        f = get_historical_data("AAPL", self.good_start, self.good_end,
+        f = get_historical_data("AMZN", self.good_start, self.good_end,
                                 output_format="pandas")
 
         assert isinstance(f, pd.DataFrame)
         assert len(f) == 73
 
         expected1 = f.loc["2017-02-09"]
-        assert expected1["close"] == pytest.approx(132.42, 3)
-        assert expected1["high"] == pytest.approx(132.445, 3)
+        assert expected1["close"] == pytest.approx(821.36, 3)
+        assert expected1["high"] == pytest.approx(825.0, 3)
 
         expected2 = f.loc["2017-05-24"]
-        assert expected2["close"] == pytest.approx(153.34, 3)
-        assert expected2["high"] == pytest.approx(154.17, 3)
+        assert expected2["close"] == pytest.approx(980.35, 3)
+        assert expected2["high"] == pytest.approx(981.0, 3)
 
     def test_batch_historical_json(self):
 
-        f = get_historical_data(["AAPL", "TSLA"], self.good_start,
+        f = get_historical_data(["AMZN", "TSLA"], self.good_start,
                                 self.good_end, output_format="json")
 
         assert isinstance(f, dict)
         assert len(f) == 2
-        assert sorted(list(f)) == ["AAPL", "TSLA"]
+        assert sorted(list(f)) == ["AMZN", "TSLA"]
 
-        a = f["AAPL"]
+        a = f["AMZN"]
         t = f["TSLA"]
 
         assert len(a) == 73
         assert len(t) == 73
 
         expected1 = a["2017-02-09"]
-        assert expected1["close"] == pytest.approx(132.42, 3)
-        assert expected1["high"] == pytest.approx(132.445, 3)
+        assert expected1["close"] == pytest.approx(821.36, 3)
+        assert expected1["high"] == pytest.approx(825.0, 3)
 
         expected2 = a["2017-05-24"]
-        assert expected2["close"] == pytest.approx(153.34, 3)
-        assert expected2["high"] == pytest.approx(154.17, 3)
+        assert expected2["close"] == pytest.approx(980.35, 3)
+        assert expected2["high"] == pytest.approx(981.0, 3)
 
         expected1 = t["2017-02-09"]
         assert expected1["close"] == pytest.approx(269.20, 3)
@@ -958,26 +958,26 @@ class TestHistorical(object):
 
     def test_batch_historical_pandas(self):
 
-        f = get_historical_data(["AAPL", "TSLA"], self.good_start,
+        f = get_historical_data(["AMZN", "TSLA"], self.good_start,
                                 self.good_end, output_format="pandas")
 
         assert isinstance(f, dict)
         assert len(f) == 2
-        assert sorted(list(f)) == ["AAPL", "TSLA"]
+        assert sorted(list(f)) == ["AMZN", "TSLA"]
 
-        a = f["AAPL"]
+        a = f["AMZN"]
         t = f["TSLA"]
 
         assert len(a) == 73
         assert len(t) == 73
 
         expected1 = a.loc["2017-02-09"]
-        assert expected1["close"] == pytest.approx(132.42, 3)
-        assert expected1["high"] == pytest.approx(132.445, 3)
+        assert expected1["close"] == pytest.approx(821.36, 3)
+        assert expected1["high"] == pytest.approx(825.0, 3)
 
         expected2 = a.loc["2017-05-24"]
-        assert expected2["close"] == pytest.approx(153.34, 3)
-        assert expected2["high"] == pytest.approx(154.17, 3)
+        assert expected2["close"] == pytest.approx(980.35, 3)
+        assert expected2["high"] == pytest.approx(981.0, 3)
 
         expected1 = t.loc["2017-02-09"]
         assert expected1["close"] == pytest.approx(269.20, 3)


### PR DESCRIPTION
- Deliver an empty list to denote the missing iterable data for symbols without earnings or financials (thank you @reixd)
- Change historical test cases ticker from AAPL to AMZN to avoid issues with adjusted prices (AMZN does not normally declare dividends, whereas Apple does. This may have caused some test cases to fail)

- [X] closes #xxxx
- [X] tests added / passed
- [X] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [X] added entry to docs/source/whatsnew/vLATEST.txt