### PR TITLE
Correct Travis build (setting pytest>=4)

### DIFF
--- a/iexfinance/iexdata/__init__.py
+++ b/iexfinance/iexdata/__init__.py
@@ -8,8 +8,8 @@ def get_tops(symbols=None, **kwargs):
     """
     TOPS data for a symbol or list of symbols.
 
-    TOPS provides IEX’s aggregated best quoted bid and offer position in near
-    real time for all securities on IEX’s displayed limit order book. TOPS is
+    TOPS provides IEX's aggregated best quoted bid and offer position in near
+    real time for all securities on IEX's displayed limit order book. TOPS is
     ideal for developers needing both quote and trade data.
 
     Reference: https://iexcloud.io/docs/api/#tops
@@ -82,7 +82,7 @@ def get_deep_book(symbols=None, **kwargs):
     """
     Book data for a symbol or list of symbols
 
-    Book shows IEX’s bids and asks for given symbols.
+    Book shows IEX's bids and asks for given symbols.
 
     Reference: https://iexcloud.io/docs/api/#deep-book
     Data Weighting: ``Free``

--- a/iexfinance/stocks/base.py
+++ b/iexfinance/stocks/base.py
@@ -338,17 +338,17 @@ class Stock(_IEXBase):
 
         This returns an array of effective spread, eligible volume, and price
         improvement of a stock, by market. Unlike ``volume-by-venue``, this
-        will only return a venue if effective spread is not ‘N/A’. Values are
+        will only return a venue if effective spread is not 'N/A'. Values are
         sorted in descending order by ``effectiveSpread``. Lower
         ``effectiveSpread`` and higher ``priceImprovement`` values are
         generally considered optimal.
 
         Effective spread is designed to measure marketable orders executed in
-        relation to the market center’s quoted spread and takes into account
+        relation to the market center's quoted spread and takes into account
         hidden and midpoint liquidity available at each market center.
         Effective Spread is calculated by using eligible trade prices recorded
         to the consolidated tape and comparing those trade prices to the
-        National Best Bid and Offer (“NBBO”) at the time of the execution.
+        National Best Bid and Offer ("NBBO") at the time of the execution.
 
         View the data disclaimer at the bottom of the stocks app for more
         information about how these values are calculated.

--- a/iexfinance/tests/test_stocks.py
+++ b/iexfinance/tests/test_stocks.py
@@ -38,13 +38,13 @@ class TestBase(object):
 class TestShareDefault(object):
 
     def setup_class(self):
-        self.cshare = Stock("aapl")
-        self.cshare2 = Stock("aapl", output_format='pandas')
-        self.cshare3 = Stock("svxy")
-        self.cshare4 = Stock("aapl",
+        self.cshare = Stock("AAPL")
+        self.cshare2 = Stock("AAPL", output_format='pandas')
+        self.cshare3 = Stock("SVXY")
+        self.cshare4 = Stock("AAPL",
                              json_parse_int=Decimal,
                              json_parse_float=Decimal)
-        self.cshare5 = Stock("gig^")
+        self.cshare5 = Stock("GIG^")
 
     @pytest.mark.xfail(reason="Unstable.")
     @pytest.mark.legacy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 flake8
-pytest
+pytest>=4
 pytest-runner
 requests-cache
 six


### PR DESCRIPTION
https://travis-ci.com/gliptak/iexfinance/builds/107558252

```3.4``` fails with ```ERROR: Sphinx requires at least Python 3.5 to run.```

Others fail on earnings unit tests.