### PR TITLE
TST: Repair failing tests with new field counts from provider

### DIFF
--- a/iexfinance/tests/stocks/test_endpoints.py
+++ b/iexfinance/tests/stocks/test_endpoints.py
@@ -365,8 +365,6 @@ class TestHistoricalIntraday(object):
     def verify_timeframe(self, data):
         assert data.index[0].hour == 9
         assert data.index[0].minute == 30
-        assert data.index[-1].hour == 15
-        assert data.index[-1].minute == 59
 
     def test_intraday_fails_no_symbol(self):
         with pytest.raises(TypeError):

--- a/iexfinance/tests/test_altdata.py
+++ b/iexfinance/tests/test_altdata.py
@@ -26,16 +26,15 @@ class TestAltData(object):
         data = get_crypto_quote("BTCUSDT")
 
         assert isinstance(data, dict)
-        assert len(data) == 44
+        assert len(data) == 18
 
         assert data["symbol"] == "BTCUSDT"
-        assert len(data["primaryExchange"]) == 6
 
     def test_crypto_quote_pandas(self):
         data = get_crypto_quote("BTCUSDT", output_format='pandas')
 
         assert isinstance(data, pd.DataFrame)
-        assert len(data) == 44
+        assert len(data) == 18
 
 
 class TestSocialSentiment(object):


### PR DESCRIPTION
* ``get_crypto_quotes`` - provider returns 18 fields instead of 44
* Removed end of day checks from ``get_historical_intraday`` which caused tests to fail during market hours

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`