### PR TITLE
TST: Allow all numerical types in numerical value checks

### DIFF
--- a/iexfinance/tests/stocks/test_endpoints.py
+++ b/iexfinance/tests/stocks/test_endpoints.py
@@ -100,7 +100,7 @@ class TestShareDefault(object):
     def test_filter(self):
         data = self.cshare.get_quote(filter_='ytdChange')
         assert isinstance(data, dict)
-        assert isinstance(data["ytdChange"], (int, float))
+        assert pd.api.is_number(data["ytdChange"])
 
         data4 = self.cshare4.get_quote(filter_='ytdChange')
         assert isinstance(data4, dict)

--- a/iexfinance/tests/stocks/test_formats.py
+++ b/iexfinance/tests/stocks/test_formats.py
@@ -2,6 +2,9 @@ import pandas as pd
 import pytest
 
 
+NUMBER = [float, int]
+
+
 _ALL_METHODS = [
         ("get_balance_sheet", dict, pd.DataFrame, 27),
         ("get_book", dict, 5),
@@ -77,7 +80,10 @@ def _format_helper(obj, meta, r_type=None):
     if r_type is not None:
         assert isinstance(data, r_type)
     else:
-        assert isinstance(data, (meta[1], dict))
+        if meta[1] in NUMBER:
+            assert pd.api.is_number(data)
+        else:
+            assert isinstance(data, (meta[1], dict))
 
 
 class TestStocksJson(object):


### PR DESCRIPTION
Uses ``pandas.api.is_number`` to check numerical values returned. This should repair many issues where ``int``s are returned for precise values
