### PR TITLE
PERF: Optimize Stocks get_historical_data to reduce message count in queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,6 +218,12 @@ requested over the desired date range (``start`` and ``end`` passed as
 
     df = get_historical_data("TSLA", start, end)
 
+To obtain daily closing prices only (reduces message count), set
+``close_only=True``:
+
+.. code:: python
+
+    df = get_historical_data("TSLA", "20190617", close_only=True)
 
 For Pandas DataFrame output formatting, pass ``output_format``:
 

--- a/docs/source/stocks.rst
+++ b/docs/source/stocks.rst
@@ -26,7 +26,9 @@ more symbols (equities, ETFs, etc.) and allows access to most endpoints:
 
 Certain endpoints such as :ref:`Historical Data<stocks.historical>`,
 which are unrelated to specific symbols, are supported by top-level functions
-(i.e. ``iexfinance.stocks.get_historical_data``).
+(i.e. ``iexfinance.stocks.get_historical_data``). This function is
+**optimized** to achieve the lowest possible message count for retrieval in a
+single request.
 
 .. ipython:: python
 
@@ -336,6 +338,13 @@ Fund Ownership
 Historical Prices
 -----------------
 
+.. note:: The ``Stock.get_historical_prices`` method is an *exact* mirror of
+          the ``Historical Prices`` (chart) endpoint and accepts all
+          parameters, but is **not optimized**. Use ``get_historical_data`` for
+          optimized message counts. ``get_historical_data`` accepts ``start``,
+          ``end`` (optional) along with the parameter ``close_only``, and no
+          other parameters.
+
 The method used to obtain historical prices from a ``Stock`` object:
 
 .. ipython:: python
@@ -346,12 +355,13 @@ The method used to obtain historical prices from a ``Stock`` object:
     aapl.get_historical_prices()
 
 
-Historical time series data is also available through the
-``get_historical_prices`` method or the top-level ``get_historical_data`` and
-``get_historical_intraday`` functions of ``stocks``, which source the `Historical Prices <https://iexcloud.io/docs/api/#historical-prices>`__ endpoint.
+Historical time series data is also available through the **optimized**
+top-level ``get_historical_data`` and
+``get_historical_intraday`` functions of ``stocks``, which source the
+`Historical Prices <https://iexcloud.io/docs/api/#historical-prices>`__
+endpoint, and accept a date or date range for retrieval.
 
-Daily data can be retrieved from up to 5 years before the current date, and
-historical data up to 3 months prior to the current date.
+Daily data can be retrieved from up to 10 years before the current date.
 
 Daily
 ~~~~~
@@ -361,8 +371,8 @@ To obtain daily historical data, use ``get_historical_data``.
 .. autofunction:: iexfinance.stocks.get_historical_data
 
 
-If no date parameters are passed, the start date will default to 2015/1/1
-and the end date will default to the current date.
+Example
+^^^^^^^
 
 
 .. ipython:: python
@@ -397,6 +407,17 @@ and a single date.**
     data = get_historical_intraday("AAPL", date, output_format='pandas')
     data.head()
 
+Closing Prices Only
+^^^^^^^^^^^^^^^^^^^
+
+To retrieve closing prices only, use ``get_historical_data`` and set
+``close_only=True``:
+
+.. ipython:: python
+
+    from iexfinance.stocks import get_historical_data
+
+    get_historical_data("AAPL", "20190617", close_only=True)
 
 
 .. _stocks.income_statement:

--- a/docs/source/stocks.rst
+++ b/docs/source/stocks.rst
@@ -339,7 +339,7 @@ Historical Prices
 -----------------
 
 .. note:: The ``Stock.get_historical_prices`` method is an *exact* mirror of
-          the ``Historical Prices`` (chart) endpoint and accepts all
+          the Historical Prices (chart) endpoint and accepts all
           parameters, but is **not optimized**. Use ``get_historical_data`` for
           optimized message counts. ``get_historical_data`` accepts ``start``,
           ``end`` (optional) along with the parameter ``close_only``, and no

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -6,6 +6,8 @@ What's New
 
 New features, bug fixes, and improvements for each release.
 
+.. include:: whatsnew/v0.4.2.txt
+
 .. include:: whatsnew/v0.4.1.txt
 
 .. include:: whatsnew/v0.4.0.txt

--- a/docs/source/whatsnew/v0.4.2.txt
+++ b/docs/source/whatsnew/v0.4.2.txt
@@ -38,7 +38,7 @@ Enhancements
   retrieval of adjusted close only at reduced message cost (through
   ``chartCloseOnly`` query parameter)
 - Optimize ``get_historical_data`` to use ``chartByDay`` if a single date is
-  passed which reduces message count
+  passed which reduces message count (thanks shlomikushchi)
 
 Backwards Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/whatsnew/v0.4.2.txt
+++ b/docs/source/whatsnew/v0.4.2.txt
@@ -10,8 +10,9 @@ maintain compatibility with IEX Cloud.
 Highlights:
 
 - Removes support for the legacy Version 1.0 IEX Developer API, which was
-retired in favor of IEX Cloud in June 2019
-
+  retired in favor of IEX Cloud in June 2019
+- Optimized retrieval of historical prices with ``get_historical_data`` to
+  allow for close prices only and single day charts to reduce message counts
 
 New Endpoints
 ~~~~~~~~~~~~~
@@ -25,14 +26,19 @@ Enhancements
 ~~~~~~~~~~~~
 
 - Adds logging for queries, including message count usage and debugging
-information. Logging level defaults to ``WARNING``, but can be set to other
-levels through the ``IEX_LOG_LEVEL`` environment variable. The following levels
-provide various information:
+  information. Logging level defaults to ``WARNING``, but can be set to other
+  levels through the ``IEX_LOG_LEVEL`` environment variable. The following
+  levels provide various information:
 
     - ``WARNING`` - errors only
     - ``INFO`` - message count used
     - ``DEBUG`` - request information
 
+- Add ``close_only`` keyword argument to ``get_historical_data`` to allow for
+  retrieval of adjusted close only at reduced message cost (through
+  ``chartCloseOnly`` query parameter)
+- Optimize ``get_historical_data`` to use ``chartByDay`` if a single date is
+  passed which reduces message count
 
 Backwards Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -47,6 +53,7 @@ Backwards Incompatible Changes
     - ``iexfinance.refdata.get_iex_dividends``
     - ``iexfinance.refdata.get_iex_next_day_ex_date``
     - ``iexfinance.refdata.get_listed_symbol_dir``
+
 - The ``get_all`` method of ``iexfinance.stocks.Stock`` has been immediately
   deprecated
 

--- a/iexfinance/stocks/__init__.py
+++ b/iexfinance/stocks/__init__.py
@@ -7,7 +7,6 @@ from iexfinance.stocks.marketvolume import MarketVolumeReader
 from iexfinance.stocks.movers import MoversReader
 from iexfinance.stocks.sectorperformance import SectorPerformanceReader
 from iexfinance.stocks.todayearnings import EarningsReader
-from iexfinance.utils import _sanitize_dates
 from iexfinance.utils.exceptions import ImmediateDeprecationError
 # Data provided for free by IEX
 # See https://iextrading.com/api-exhibit-a/ for additional information

--- a/iexfinance/stocks/__init__.py
+++ b/iexfinance/stocks/__init__.py
@@ -14,19 +14,24 @@ from iexfinance.utils.exceptions import ImmediateDeprecationError
 # and conditions of use
 
 
-def get_historical_data(symbols, start=None, end=None, **kwargs):
+def get_historical_data(symbols, start, end=None, close_only=False, **kwargs):
     """
     Function to obtain historical date for a symbol or list of
     symbols. Return an instance of HistoricalReader
+
+    Reference: https://iextrading.com/developer/docs/#chart
 
     Parameters
     ----------
     symbols: str or list
         A symbol or list of symbols
-    start: datetime.datetime, default None
+    start: datetime.datetime
         Beginning of desired date range
-    end: datetime.datetime, default None
+    end: datetime.datetime, optional, default None
         End of required date range
+    close_only: bool, default False
+        Returns adjusted data only with keys ``date``, ``close``, and
+        ``volume``
     kwargs:
         Additional Request Parameters (see base class)
 
@@ -35,8 +40,8 @@ def get_historical_data(symbols, start=None, end=None, **kwargs):
     list or DataFrame
         Historical stock prices over date range, start to end
     """
-    start, end = _sanitize_dates(start, end)
-    return HistoricalReader(symbols, start=start, end=end, **kwargs).fetch()
+    return HistoricalReader(symbols, start=start, end=end,
+                            close_only=close_only, **kwargs).fetch()
 
 
 def get_historical_intraday(symbol, date=None, **kwargs):

--- a/iexfinance/tests/stocks/test_endpoints.py
+++ b/iexfinance/tests/stocks/test_endpoints.py
@@ -287,6 +287,22 @@ class TestHistorical(object):
         with pytest.raises(IEXSymbolError):
             get_historical_data(["BADSYMBOL", "TSLA"], start, end)
 
+    def test_string_dates(self):
+        start = "20190501"
+        end = "20190601"
+
+        data = get_historical_data("AAPL", start, end, output_format='pandas')
+
+        assert isinstance(data, pd.DataFrame)
+        assert len(data) == 22
+
+    def test_close_only(self):
+        data = get_historical_data("AAPL", self.good_start, self.good_end,
+                                   close_only=True)
+
+        assert "open" not in data["2017-02-09"]
+        assert "high" not in data["2017-02-09"]
+
 
 class TestSectorPerformance(object):
 

--- a/iexfinance/utils/__init__.py
+++ b/iexfinance/utils/__init__.py
@@ -15,7 +15,7 @@ def _init_session(session, retry_count=3):
     return session
 
 
-def _sanitize_dates(start, end):
+def _sanitize_dates(start, end, default_end=datetime.today()):
     """
     Return (datetime_start, datetime_end) tuple
     if start is None - default is 2015/01/01
@@ -33,8 +33,8 @@ def _sanitize_dates(start, end):
     if start is None:
         start = datetime(2015, 1, 1)
     if end is None:
-        end = datetime.today()
-    if start > end:
+        end = default_end
+    if default_end is not None and start > end:
         raise ValueError('start must be an earlier date than end')
     return start, end
 


### PR DESCRIPTION
As noted by @shlomikushchi in #148, ``HistoricalReader`` is not currently optimized for single day requests and for retrieving close only.

## Enhancements

* Add ``close_only`` parameter to ``get_historical_data`` to allow retrieval of close prices only to reduce message count (through ``chartCloseOnly``)
* Optimize single-day requests to ``get_historical_data`` such that they use ``date`` as a range and set ``chartByDay`` to ``True``

## Documentation

Clarifies documentation to specify ``get_historical_data`` as *optimized* and accepting a date range and ``close_only`` as parameters, while ``Stock.get_historical_prices`` is an exact mirror of the Historical Prices endpoint which accepts any parameter from the IEX docs

- [ ] closes #xxxx
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt