### PR TITLE
ENH: Add support for End of Day Options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ Forex/Currencies, Options, Commodities, Bonds, and Cryptocurrencies:
 - Real-time and delayed quotes
 - Historical data (daily and minutely)
 - Financial statements (Balance Sheet, Income Statement, Cash Flow)
+- End of Day Options Prices
 - Institutional and Fund ownership
 - Analyst estimates, Price targets
 - Corporate actions (Dividends, Splits)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ Full Contents
    data_apis
    altdata
    refdata
+   options
    iexdata
    apidata
 

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -1,0 +1,57 @@
+.. _options:
+
+Options
+=======
+
+.. _options.eod:
+
+End of Day Options
+------------------
+
+End of day options prices are available through the top-level function
+``get_eod_options`` for a single symbol.
+
+.. autofunction:: iexfinance.stocks.get_eod_options
+
+.. _options.eod.expiry_list:
+
+List of Expiration Dates
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To obtain a list of all options expiration dates for a symbol, simply call ``get_eod_options`` with a symbol only:
+
+.. ipython:: python
+
+    from iexfinance.stocks import get_eod_options
+
+    get_eod_options("AAPL", output_format='pandas').head()
+
+
+.. _options.eod.single_date:
+
+Options For A Single Date
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To obtain the end-of-day prices of options contracts for a single expiration date (in the form ``YYYYMM``):
+
+.. code-block:: python
+
+    get_eod_options("AAPL", "201906")
+
+
+.. _options.eod.filter:
+
+Calls/Puts Only
+~~~~~~~~~~~~~~~
+
+It is possible to limit option results to calls or puts only:
+
+.. code-block:: python
+
+    get_eod_options("AAPL", "201906", "calls")
+
+or:
+
+.. code-block:: python
+
+    get_eod_options("AAPL", "201906", "puts")

--- a/docs/source/stocks.rst
+++ b/docs/source/stocks.rst
@@ -79,6 +79,7 @@ Endpoints which are supported by top-level functions are noted.
 - :ref:`News<stocks.news>`
 - :ref:`OHLC<stocks.ohlc>`
 - :ref:`Open/Close<stocks.open_close>`
+- :ref:`End of Day Options<stocks.eod_options>` - ``get_eod_options``
 - :ref:`Peers<stocks.peers>`
 - :ref:`Previous Day Prices<stocks.previous_day_prices>`
 - :ref:`Price<stocks.price>`
@@ -301,6 +302,15 @@ Examples
 
     get_earnings_today()["bto"]
 
+
+.. _stocks.eod_options:
+
+End of Day Options
+------------------
+
+End of day options prices are available through the top-level function ``get_eod_options``.
+
+.. autofunction:: iexfinance.stocks.get_eod_options
 
 .. _stocks.estimates:
 

--- a/docs/source/whatsnew/v0.4.2.txt
+++ b/docs/source/whatsnew/v0.4.2.txt
@@ -17,6 +17,10 @@ Highlights:
 New Endpoints
 ~~~~~~~~~~~~~
 
+**Options**
+
+- End of Day Options (``get_eod_options``)
+
 **Data APIs**
 
 - /time-series (``get_time_series``)

--- a/iexfinance/stocks/__init__.py
+++ b/iexfinance/stocks/__init__.py
@@ -5,6 +5,7 @@ from iexfinance.stocks.historical import HistoricalReader, IntradayReader
 from iexfinance.stocks.ipocalendar import IPOReader
 from iexfinance.stocks.marketvolume import MarketVolumeReader
 from iexfinance.stocks.movers import MoversReader
+from iexfinance.stocks.options import OptionsReader
 from iexfinance.stocks.sectorperformance import SectorPerformanceReader
 from iexfinance.stocks.todayearnings import EarningsReader
 from iexfinance.utils.exceptions import ImmediateDeprecationError
@@ -254,3 +255,26 @@ def get_market_in_focus(**kwargs):
     list
     """
     return MoversReader(mover='infocus', **kwargs).fetch()
+
+
+def get_eod_options(symbol, expiration=None, option_side=None, **kwargs):
+    """
+    End of Day Options
+
+    Returns a list of option expiration dates for a given symbol
+
+    Reference: https://iexcloud.io/docs/api/#end-of-day-options
+
+
+    Parameters
+    ----------
+    symbol: str
+        A valid symbol
+    expiration: str, optional
+        A valid expiration date
+    option_side: str, optional
+        Option side - ``put`` or ``call`` will return only those types of
+        contracts
+    """
+    return OptionsReader(symbol, expiration=expiration,
+                         option_side=option_side, **kwargs).fetch()

--- a/iexfinance/stocks/options.py
+++ b/iexfinance/stocks/options.py
@@ -1,0 +1,27 @@
+import pandas as pd
+
+from iexfinance.base import _IEXBase
+
+
+class OptionsReader(_IEXBase):
+
+    def __init__(self, symbol, expiration=None, option_side=None, **kwargs):
+        self.symbol = symbol
+        self.expiration = expiration
+        self.option_side = option_side
+        super(OptionsReader, self).__init__(**kwargs)
+
+    @property
+    def url(self):
+        if self.expiration is None:
+            return "/stock/%s/options" % self.symbol
+        if self.option_side is None:
+            return "/stock/%s/options/%s" % (self.symbol, self.expiration)
+        return "/stock/%s/options/%s/%s" % (self.symbol, self.expiration,
+                                            self.option_side)
+
+    def _convert_output(self, out):
+        if self.expiration is None:
+            return pd.DataFrame(out)
+        else:
+            return pd.DataFrame({item["expirationDate"]: item for item in out})

--- a/iexfinance/tests/stocks/test_endpoints.py
+++ b/iexfinance/tests/stocks/test_endpoints.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from iexfinance.stocks import (get_historical_data, get_sector_performance,
                                get_collections, get_earnings_today,
                                get_ipo_calendar, get_historical_intraday,
-                               Stock)
+                               Stock, get_eod_options)
 from iexfinance.utils.exceptions import IEXSymbolError, IEXEndpointError
 
 
@@ -421,3 +421,32 @@ class TestHistoricalIntraday(object):
         data = get_historical_intraday("AAPL", date=date)
 
         assert isinstance(data, list)
+
+
+class TestEODOptions(object):
+
+    def test_eod_options_no_symbol(self):
+        with pytest.raises(TypeError):
+            get_eod_options()
+
+    def test_eod_list(self):
+        data = get_eod_options("AAPL")
+
+        assert isinstance(data, list)
+        assert len(data[1]) == 6
+
+    @pytest.mark.xfail(reason="Provider scrambles expiration dates but does "
+                              "not accept scrambled dates for calls")
+    def test_single_date(self):
+        # obtain list of expiration dates (often changes)
+        expiries = get_eod_options("AAPL")
+
+        # use first date
+        data = get_eod_options("AAPL", expiries[0])
+
+        assert isinstance(data, list)
+        assert isinstance(data[0], dict)
+        assert data[0]["symbol"] == "AAPL"
+
+        data2 = get_eod_options("AAPL", expiries[0], output_format='pandas')
+        assert isinstance(data2, pd.DataFrame)


### PR DESCRIPTION
Add support for [End of Day Options](https://iexcloud.io/docs/api/#end-of-day-options)

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt