### PR TITLE
Replacing Pandas Compact

### DIFF
--- a/iexfinance/utils/__init__.py
+++ b/iexfinance/utils/__init__.py
@@ -40,7 +40,7 @@ def _sanitize_dates(start, end, default_end=datetime.today()):
 
 
 def _handle_lists(l, mult=True, err_msg=None):
-    if isinstance(l, (compat.string_types, int)):
+    if isinstance(l, (str, int)):
         return [l] if mult is True else l
     elif isinstance(l, pd.DataFrame) and mult is True:
         return list(l.index)


### PR DESCRIPTION
* Issue
 pandas version 0.24> compact is no longer available
* fix
Pandas compact string type in python3 provides only (str,) support and in python2 provides (str, URL)

resolves: https://github.com/addisonlynch/iexfinance/issues/163

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt