### PR TITLE
BUG: Return all fields from Stock.get_historical_prices and Stock.get_chart

### DIFF
--- a/docs/source/whatsnew/v0.4.4.txt
+++ b/docs/source/whatsnew/v0.4.4.txt
@@ -1,0 +1,16 @@
+.. _whatsnew_044:
+
+
+v0.4.4 (TBD)
+------------
+
+This is a minor patch release from 0.4.3. We recommend that all users upgrade.
+
+
+Bug Fixes
+~~~~~~~~~
+
+- Modifies ``Stock.get_historical_prices`` and ``Stock.get_chart``
+  (GH165_) to return all fields, including ``changePercent``
+
+  .. _GH165:: https://github.com/addisonlynch/iexfinance/issues/165

--- a/iexfinance/stocks/base.py
+++ b/iexfinance/stocks/base.py
@@ -469,8 +469,6 @@ class Stock(_IEXBase):
                 d = out.pop(symbol)
                 df = pd.DataFrame(d)
                 df.set_index(pd.DatetimeIndex(df["date"]), inplace=True)
-                values = ["open", "high", "low", "close", "volume"]
-                df = df[values]
                 result.update({symbol: df})
             if len(result) == 1:
                 return result[self.symbols[0]]


### PR DESCRIPTION
``Stock.get_historical_prices`` and ``Stock.get_chart`` were truncated to only return ``Open``, ``High``, ``Low``, and ``Close`` fields. These have been modified to now return all fields (see below)

![image](https://user-images.githubusercontent.com/21162161/63893410-141b2700-c9b8-11e9-95c1-24c17f3319eb.png)


- [x] closes #165 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt