### PR TITLE
ENH/BUG: Optimize historical message weighting, allow 15 years of data

### DIFF
--- a/docs/source/stocks.rst
+++ b/docs/source/stocks.rst
@@ -360,7 +360,7 @@ top-level ``get_historical_data`` and
 `Historical Prices <https://iexcloud.io/docs/api/#historical-prices>`__
 endpoint, and accept a date or date range for retrieval.
 
-Daily data can be retrieved from up to 10 years before the current date.
+Daily data can be retrieved from up to 15 years before the current date.
 
 Daily
 ~~~~~

--- a/docs/source/whatsnew/v0.4.4.txt
+++ b/docs/source/whatsnew/v0.4.4.txt
@@ -7,6 +7,17 @@ v0.4.4 (TBD)
 This is a minor patch release from 0.4.3. We recommend that all users upgrade.
 
 
+Enhancements
+~~~~~~~~~~~~
+
+- Improves message weighting for historical data when calls are under
+  1-year range
+- Adds support for historical data for the previous 15 years
+  (extended from 5 years) (GH94_)
+
+.. _GH94:: https://github.com/addisonlynch/iexfinance/issues/94
+
+
 Bug Fixes
 ~~~~~~~~~
 

--- a/iexfinance/stocks/historical.py
+++ b/iexfinance/stocks/historical.py
@@ -21,22 +21,33 @@ class HistoricalReader(Stock):
 
     @property
     def chart_range(self):
-        """ Calculates the chart range from start and end. Downloads larger
-        datasets (5y and 2y) when necessary, but defaults to 1y for performance
-        reasons
+        """ Calculates the chart range from start and end
         """
         if self.single_day is True:
             return "date"
         delta = datetime.datetime.now().year - self.start.year
-        if 2 <= delta <= 5:
+        if 5 <= delta <= 15:
+            return "max"
+        if 2 <= delta < 5:
             return "5y"
-        elif 1 <= delta <= 2:
+        elif 1 <= delta < 2:
             return "2y"
         elif 0 <= delta < 1:
-            return "1y"
+            # source: pandas datareader
+            delta_days = (datetime.datetime.now() - self.start).days
+            if 0 <= delta_days < 6:
+                return "5d"
+            elif 6 <= delta_days < 28:
+                return "1m"
+            elif 28 <= delta_days < 84:
+                return "3m"
+            elif 84 <= delta_days < 168:
+                return "6m"
+            else:
+                return "1y"
         else:
             raise ValueError(
-                "Invalid date specified. Must be within past 5 years.")
+                "Invalid date specified. Must be within past 15 years.")
 
     @property
     def params(self):

--- a/iexfinance/tests/stocks/test_endpoints.py
+++ b/iexfinance/tests/stocks/test_endpoints.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from decimal import Decimal
 
+from iexfinance.stocks.historical import HistoricalReader
 from iexfinance.stocks import (get_historical_data, get_sector_performance,
                                get_collections, get_earnings_today,
                                get_ipo_calendar, get_historical_intraday,
@@ -270,13 +271,13 @@ class TestHistorical(object):
         assert expected2["high"] == pytest.approx(311.0, 3)
 
     def test_invalid_dates(self):
-        start = datetime(2010, 5, 9)
+        start = datetime(2000, 5, 9)
         end = datetime(2017, 5, 9)
         with pytest.raises(ValueError):
             get_historical_data("AAPL", start, end)
 
     def test_invalid_dates_batch(self):
-        start = datetime(2010, 5, 9)
+        start = datetime(2000, 5, 9)
         end = datetime(2017, 5, 9)
         with pytest.raises(ValueError):
             get_historical_data(["AAPL", "TSLA"], start, end)
@@ -303,9 +304,37 @@ class TestHistorical(object):
         assert "open" not in data["2017-02-09"]
         assert "high" not in data["2017-02-09"]
 
-    # def test_market_closed_pandas(self):
-    #     data = get_historical_data("AAPL", "20190101")
-    #     assert isinstance(data, pd.DataFrame)
+    def test_reader_chart_range(self):
+        from datetime import date, timedelta
+
+        syms = ["AAPL"]
+
+        # source: pandas datareader
+
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=5),
+                                end=date.today()).chart_range == '5d'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=27),
+                                end=date.today()).chart_range == '1m'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=83),
+                                end=date.today()).chart_range == '3m'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=167),
+                                end=date.today()).chart_range == '6m'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=170),
+                                end=date.today()).chart_range == '1y'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=365),
+                                end=date.today()).chart_range == '2y'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=730),
+                                end=date.today()).chart_range == '5y'
+        assert HistoricalReader(symbols=syms,
+                                start=date.today() - timedelta(days=1826),
+                                end=date.today()).chart_range == 'max'
 
 
 class TestSectorPerformance(object):


### PR DESCRIPTION
- [x] closes #94, #154 
- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt