### PR TITLE
ENH/BUG: Repair date handling

### DIFF
--- a/docs/source/whatsnew/v0.5.0.txt
+++ b/docs/source/whatsnew/v0.5.0.txt
@@ -17,6 +17,8 @@ Enhancements
 - Adds support for historical data for the previous 15 years
   (extended from 5 years) (GH94_)
 - Adds ``flake8-bugbear`` for additional code quality checks
+- Repairs date handling to accept multiple formats, including ``str``,
+  ``int``, ``date``, ``datetime``, and ``pandas.Timestamp`` and use a rolling 15-year default start date for historical data (specifically ``get_historical_data``)
 
 .. _GH94:: https://github.com/addisonlynch/iexfinance/issues/94
 

--- a/iexfinance/iexdata/__init__.py
+++ b/iexfinance/iexdata/__init__.py
@@ -158,10 +158,12 @@ def get_stats_daily(start=None, end=None, last=None, **kwargs):
 
     Parameters
     ----------
-    start: datetime.datetime, default None, optional
-        Start of data retrieval period
-    end: datetime.datetime, default None, optional
-        End of data retrieval period
+    start : string, int, date, datetime, Timestamp
+        Starting date. Parses many different kind of date
+        representations (e.g., 'JAN-01-2010', '1/1/10', 'Jan, 1, 1980').
+        Defaults to 15 years before current date.
+    end : string, int, date, datetime, Timestamp
+        Ending date
     last: int, default None, optional
         Used in place of date range to retrieve previous number of trading days
         (up to 90)

--- a/iexfinance/stocks/__init__.py
+++ b/iexfinance/stocks/__init__.py
@@ -25,10 +25,12 @@ def get_historical_data(symbols, start, end=None, close_only=False, **kwargs):
     ----------
     symbols: str or list
         A symbol or list of symbols
-    start: datetime.datetime
-        Beginning of desired date range
-    end: datetime.datetime, optional, default None
-        End of required date range
+    start : string, int, date, datetime, Timestamp
+        Starting date. Parses many different kind of date
+        representations (e.g., 'JAN-01-2010', '1/1/10', 'Jan, 1, 1980').
+        Defaults to 15 years before current date.
+    end : string, int, date, datetime, Timestamp
+        Ending date
     close_only: bool, default False
         Returns adjusted data only with keys ``date``, ``close``, and
         ``volume``

--- a/iexfinance/stocks/historical.py
+++ b/iexfinance/stocks/historical.py
@@ -14,7 +14,7 @@ class HistoricalReader(Stock):
     Reference: https://iextrading.com/developer/docs/#chart
     """
     def __init__(self, symbols, start, end=None, close_only=False, **kwargs):
-        self.start, self.end = _sanitize_dates(start, end, default_end=None)
+        self.start, self.end = _sanitize_dates(start, end)
         self.single_day = True if self.end is None else False
         self.close_only = close_only
         super(HistoricalReader, self).__init__(symbols, **kwargs)

--- a/iexfinance/tests/test_iexdata.py
+++ b/iexfinance/tests/test_iexdata.py
@@ -213,9 +213,6 @@ class TestStatsSummary(object):
 
     def test_summary_invalid_end_date(self):
         with pytest.raises(ValueError):
-            get_stats_summary(start=datetime(2017, 1, 1))
-
-        with pytest.raises(ValueError):
             get_stats_summary(start=datetime(2017, 1, 1), end=datetime(2016, 1,
                               1))
 

--- a/iexfinance/tests/test_utils.py
+++ b/iexfinance/tests/test_utils.py
@@ -1,4 +1,4 @@
-import datetime
+import datetime as dt
 import pytest
 import pandas as pd
 
@@ -44,28 +44,48 @@ class TestUtils(object):
         with pytest.raises(ValueError):
             _handle_lists(mult, mult=False)
 
-    def test_sanitize_dates_years(self):
-        expected = (datetime.datetime(2017, 1, 1),
-                    datetime.datetime(2018, 1, 1))
-        assert _sanitize_dates(2017, 2018) == expected
+    @pytest.mark.parametrize(
+        "input_date",
+        [
+            "2019-01-01",
+            "JAN-01-2010",
+            dt.datetime(2019, 1, 1),
+            dt.date(2019, 1, 1),
+            pd.Timestamp(2019, 1, 1),
+        ],
+    )
+    def test_sanitize_dates(self, input_date):
+        expected_start = pd.to_datetime(input_date)
+        expected_end = pd.to_datetime(dt.date.today())
+        result = _sanitize_dates(input_date, None)
+        assert result == (expected_start, expected_end)
 
-    def test_sanitize_dates_default(self):
-        exp_start = datetime.datetime(2015, 1, 1, 0, 0)
-        exp_end = datetime.datetime.today()
-        start, end = _sanitize_dates(None, None)
+    def test_sanitize_dates_int(self):
+        start_int = 2018
+        end_int = 2019
+        expected_start = pd.to_datetime(dt.datetime(start_int, 1, 1))
+        expected_end = pd.to_datetime(dt.datetime(end_int, 1, 1))
+        assert _sanitize_dates(start_int, end_int) == (expected_start,
+                                                       expected_end)
 
-        assert start == exp_start
-        assert end.date() == exp_end.date()
-
-    def test_sanitize_dates(self):
-        start = datetime.datetime(2017, 3, 4)
-        end = datetime.datetime(2018, 3, 9)
-
-        assert _sanitize_dates(start, end) == (start, end)
-
-    def test_sanitize_dates_error(self):
-        start = datetime.datetime(2018, 1, 1)
-        end = datetime.datetime(2017, 1, 1)
+    def test_sanitize_invalid_dates(self):
+        with pytest.raises(ValueError):
+            _sanitize_dates(2019, 2018)
 
         with pytest.raises(ValueError):
-            _sanitize_dates(start, end)
+            _sanitize_dates("2019-01-01", "2018-01-01")
+
+        with pytest.raises(ValueError):
+            _sanitize_dates("20199", None)
+
+        with pytest.raises(ValueError):
+            _sanitize_dates(2022, None)
+
+        with pytest.raises(ValueError):
+            _sanitize_dates(None, 2022)
+
+    def test_sanitize_dates_defaults(self):
+        start_raw = dt.date.today() - dt.timedelta(days=365 * 15)
+        default_start = pd.to_datetime(start_raw)
+        default_end = pd.to_datetime(dt.date.today())
+        assert _sanitize_dates(None, None) == (default_start, default_end)


### PR DESCRIPTION
Repairs all date handling

* Use rolling 15 year default start date
* Accept multiple formats, including ``int``, ``str``, ``date``, ``datetime``, and ``pandas.Timestamp``

- [x] tests added / passed
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt