### PR TITLE
Explicit error handling for incorrect number of Stock symbols

### DIFF
--- a/iexfinance/stocks/base.py
+++ b/iexfinance/stocks/base.py
@@ -40,6 +40,8 @@ class Stock(_IEXBase):
             self.symbols = [symbols]
         elif isinstance(symbols, list) and 0 < len(symbols) <= 100:
             self.symbols = symbols
+        elif 0 < len(symbols) <= 100:
+            raise ValueError("Please input a symbols list containing between 0 and 100 symbols")
         else:
             raise ValueError("Please input a symbol or list of symbols")
         self.symbols = list(map(lambda x: x.upper(), _handle_lists(symbols)))


### PR DESCRIPTION
Added more specific error message. As currently is, took me coming to the source code to debug the original error message.

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt