### PR TITLE
BUG/TST: Repair failing tests and restore CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - python: 3.4
-      env: PANDAS=0.23 NUMPY=1.13
-      dist: trusty
     - python: 3.5
       env: PANDAS=0.23 NUMPY=1.13
       dist: trusty

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -180,6 +180,4 @@ texinfo_documents = [
 ]
 
 # extlinks
-extlinks = {
-    'issue': ('https://github.com/addisonlynch/iexfinance/issues/%s', 'GH')
-}
+extlinks = {"issue": ("https://github.com/addisonlynch/iexfinance/issues/%s", "GH")}

--- a/docs/source/market-info.rst
+++ b/docs/source/market-info.rst
@@ -1,5 +1,7 @@
 .. _market-info:
 
+.. currentmodule:: iexfinance
+
 Market Info
 ===========
 
@@ -35,7 +37,7 @@ by:
 Use ``get_collections`` to access.
 
 
-.. autofunction:: iexfinance.market-info.get_collections
+.. autofunction:: iexfinance.stocks.get_collections
 
 
 .. _market-info.collections.examples:
@@ -73,7 +75,7 @@ Earnings Today was added to the Stocks endpoints in 2018. Access is provided
 through the  ``get_earnings_today`` function.
 
 
-.. autofunction:: iexfinance.market-info.get_earnings_today
+.. autofunction:: iexfinance.stocks.get_earnings_today
 
 
 .. note:: ``get_earnings_today`` supports JSON output formatting only.
@@ -98,7 +100,7 @@ IPO Calendar
 IPO Calendar was added to the Stocks endpoints in 2018. Access is provided
 through the  ``get_ipo_calendar`` function.
 
-.. autofunction:: iexfinance.market-info.get_ipo_calendar
+.. autofunction:: iexfinance.stocks.get_ipo_calendar
 
 There are two possible values for the ``period`` parameter, of which
 ``upcoming-ipos`` is the default. ``today-ipos`` is also available.
@@ -118,7 +120,7 @@ Examples
 
 List
 ----
-.. seealso:: :ref:`Market Movers<market-info.movers>`
+.. seealso:: :ref:`Market Movers<stocks.movers>`
 
 .. _market-info.market_volume:
 
@@ -129,7 +131,7 @@ Market Volume returns real-time traded volume on U.S. Markets. Access is
 provided through the ``get_market_volume`` function.
 
 
-.. autofunction:: iexfinance.market-info.get_market_volume
+.. autofunction:: iexfinance.stocks.get_market_volume
 
 
 .. _market-info.market_volume.examples:
@@ -151,4 +153,4 @@ Sector Performance
 
 Sector Performance was added to the Stocks endpoints in 2018. Access to this endpoint is provided through the ``get_sector_performance`` function.
 
-.. autofunction:: iexfinance.market-info.get_sector_performance
+.. autofunction:: iexfinance.stocks.get_sector_performance

--- a/docs/source/stocks.rst
+++ b/docs/source/stocks.rst
@@ -438,7 +438,7 @@ Splits (Basic)
 
 Time Series
 -----------
-.. seealso:: Time Series is an alias for the :ref:`Chart<stocks.chart>` endpoint
+.. seealso:: Time Series is an alias for the :ref:`Chart<stocks.charts>` endpoint
 
 .. automethod:: iexfinance.stocks.base.Stock.get_time_series
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -175,7 +175,7 @@ Certain endpoints (such as quote and chart), however, allow customizable
 parameters. To specify one of these parameters, merely pass it to an endpoint
 method as a keyword argument.
 
-.. ipython:: python
+.. code-block:: python
 
     aapl = Stock("AAPL", output_format='pandas')
     aapl.get_quote(displayPercent=True).loc["ytdChange"]

--- a/docs/source/whatsnew/v0.5.0.txt
+++ b/docs/source/whatsnew/v0.5.0.txt
@@ -50,7 +50,7 @@ Bug Fixes
 Backward Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Ends support for Python 2
+- Ends support for Python 2 and Python 3.4
 - All legacy IEX Developer API version 1.0 endpoints and references to such endpoints
   have been removed
 - ``Stock.get_endpoints``, ``Stock.get_short_interest``, 

--- a/iexfinance/base.py
+++ b/iexfinance/base.py
@@ -167,7 +167,7 @@ class _IEXBase(object):
         params["token"] = self.token
         headers = {"project": "iexfinance/stable (Language=Python)"}
         for _ in range(self.retry_count + 1):
-            response = self.session.get(url=url, params=params)
+            response = self.session.get(url=url, params=params, headers=headers)
             logger.debug("REQUEST: %s" % response.request.url)
             logger.debug("RESPONSE: %s" % response.status_code)
             if response.status_code == requests.codes.ok:

--- a/iexfinance/stocks/base.py
+++ b/iexfinance/stocks/base.py
@@ -191,7 +191,6 @@ class Stock(_IEXBase):
         """
 
         def format(out):
-            return out
             if len(self.symbols) > 1:
                 out = {
                     (symbol, day["date"]): day for symbol in out for day in out[symbol]

--- a/iexfinance/tests/stocks/test_field_methods.py
+++ b/iexfinance/tests/stocks/test_field_methods.py
@@ -56,19 +56,19 @@ class TestFieldMethods(object):
         data = self.a.get_company_name()
 
         assert isinstance(data, str)
-        assert data == "Apple, Inc."
+        assert data == "Apple Inc"
 
     def test_primary_exchange(self):
         data = self.a.get_primary_exchange()
 
         assert isinstance(data, str)
-        assert len(data) == 6
+        assert len(data) == 33
 
     def test_sector(self):
         data = self.a.get_sector()
 
         assert isinstance(data, str)
-        assert len(data) == 21
+        assert len(data) == 13
 
     def test_open(self):
         data = self.a.get_open()

--- a/iexfinance/tests/stocks/test_fundamentals.py
+++ b/iexfinance/tests/stocks/test_fundamentals.py
@@ -46,6 +46,9 @@ class TestStockFundamentals(object):
         assert isinstance(data["AAPL"], pd.DataFrame) and not data["AAPL"].empty
         assert isinstance(data["SVXY"], pd.DataFrame) and data["SVXY"].empty
 
+    @pytest.mark.xfail(
+        reason="Provider bug. Will not return more than 3 " "periods.", strict=True
+    )
     def test_balance_sheet_params(self):
         data = self.a.get_balance_sheet(last=4)
         assert len(data.index) == 4
@@ -56,6 +59,9 @@ class TestStockFundamentals(object):
         assert isinstance(data["AAPL"], pd.DataFrame) and not data["AAPL"].empty
         assert isinstance(data["SVXY"], pd.DataFrame) and data["SVXY"].empty
 
+    @pytest.mark.xfail(
+        reason="Provider bug. Will not return more than 3 " "periods.", strict=True
+    )
     def test_cash_flow_params(self):
         data = self.a.get_cash_flow(last=4)
         assert len(data.index) == 4
@@ -93,6 +99,9 @@ class TestStockFundamentals(object):
         assert isinstance(data["AAPL"], pd.DataFrame) and not data["AAPL"].empty
         assert isinstance(data["SVXY"], pd.DataFrame) and data["SVXY"].empty
 
+    @pytest.mark.xfail(
+        reason="Provider bug. Will not return more than 3 " "periods.", strict=True
+    )
     def test_income_statement_params(self):
         data = self.a.get_income_statement(last=4)
         assert len(data.index) == 4
@@ -102,4 +111,4 @@ class TestStockFundamentals(object):
 
         assert isinstance(data, dict)
         assert isinstance(data["AAPL"], pd.DataFrame) and not data["AAPL"].empty
-        assert isinstance(data["SVXY"], pd.DataFrame) and data["SVXY"].empty
+        assert isinstance(data["SVXY"], pd.DataFrame) and not data["SVXY"].empty

--- a/iexfinance/tests/stocks/test_ipo_calendar.py
+++ b/iexfinance/tests/stocks/test_ipo_calendar.py
@@ -4,6 +4,7 @@ from iexfinance.stocks import get_ipo_calendar
 
 
 class TestIPOCalendar(object):
+    @pytest.mark.xfail(reason="Endpoint temporarily disabled by provider.", strict=True)
     def test_ipo_calendar(self):
         data = get_ipo_calendar()
 

--- a/iexfinance/tests/stocks/test_research.py
+++ b/iexfinance/tests/stocks/test_research.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from iexfinance.stocks import Stock
 
@@ -54,6 +55,7 @@ class TestStockResearch(object):
 
         assert isinstance(data, pd.DataFrame)
 
+    @pytest.mark.xfail(reason="Requires special permission to access.")
     def test_price_target(self):
         data = self.a.get_price_target()
 

--- a/iexfinance/utils/__init__.py
+++ b/iexfinance/utils/__init__.py
@@ -25,6 +25,7 @@ def _sanitize_dates(start, end):
         Desired end date
     """
     today = dt.date.today()
+    today = to_datetime(today)
 
     if is_number(start):
         # regard int as year

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ exclude = .git,.env
 [flake8]
 max-line-length = 90
 exclude = .git,.env
+ignore = E203, W503


### PR DESCRIPTION
- Fundamentals only return 3 periods max. IEX Bug. xfail tests for now
- Price Target requires special access
- IPO Calendar endpoint temporarily disabled
- iexfinance bug: Incorrect return statement messed up output formatting for historical prices

Other maintenance items:

* Remove python 3.4 from travis
* Repair bug for pandas < 1.0 where incompatible types were compared in ``_utils._sanitize_dates``
* Repair compatibility issues between ``flake8`` and ``black``