### PR TITLE
CLN/TST: Cleanup some tests.

### DIFF
--- a/docs/source/stocks.rst
+++ b/docs/source/stocks.rst
@@ -34,7 +34,7 @@ single request.
 
     from iexfinance.stocks import get_historical_data
 
-    get_historical_data("AAPL", start="20190101", end="20200101", 
+    get_historical_data("AAPL", start="20190101", end="20200101",
                         output_format='pandas').head()
 
 
@@ -140,8 +140,8 @@ Dividends (Basic)
 Earnings
 --------
 
-.. warning:: Beginning December 1, 2020, use of this endpoint will require 
-             additional entitlements. Full details can be found in the 
+.. warning:: Beginning December 1, 2020, use of this endpoint will require
+             additional entitlements. Full details can be found in the
              IEX Cloud Help Center. See `here <https://intercom.help/iexcloud/en/articles/4529082-iex-cloud-s-2020-data-upgrade>`_
              for additional information.
 
@@ -152,8 +152,8 @@ Earnings
 Estimates
 ---------
 
-.. warning:: Beginning December 1, 2020, use of this endpoint will require 
-             additional entitlements. Full details can be found in the 
+.. warning:: Beginning December 1, 2020, use of this endpoint will require
+             additional entitlements. Full details can be found in the
              IEX Cloud Help Center. See `here <https://intercom.help/iexcloud/en/articles/4529082-iex-cloud-s-2020-data-upgrade>`_
              for additional information.
 
@@ -372,8 +372,8 @@ Price Only
 Price Target
 ------------
 
-.. warning:: Beginning December 1, 2020, use of this endpoint will require 
-             additional entitlements. Full details can be found in the 
+.. warning:: Beginning December 1, 2020, use of this endpoint will require
+             additional entitlements. Full details can be found in the
              IEX Cloud Help Center. See `here <https://intercom.help/iexcloud/en/articles/4529082-iex-cloud-s-2020-data-upgrade>`_
              for additional information.
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -61,6 +61,8 @@ A BASH script ``test.sh`` is included in the
 top-level iexfinance directory. This script will emulate the tests
 needed for a TravisCI build to pass.
 
+Note that your environment needs to export a testing IEX_TOKEN to execute tests.
+
 The ``iexfinance`` documentation can be tested with `Sphinx <https://www.sphinx-doc.org/en/stable>`__ (with extensions napoleon and sphinx_rtd_theme)
 using the Makefile. ``make livehtml`` will serve the dev documentation site locally
 on 127.0.0.1:8000.

--- a/iexfinance/base.py
+++ b/iexfinance/base.py
@@ -85,7 +85,7 @@ class _IEXBase(object):
             )
         if self.token.startswith(("Tsk", "Tpk")):
             logger.info("Using a sandboxed environment because a test key was detected")
-            os.environ["IEX_API_VERSION"] = "iexcloud-sandbox"
+            os.environ["IEX_API_VERSION"] = "sandbox"
         # Get desired API version from environment variables
         # Defaults to IEX Cloud
         self.version = os.getenv("IEX_API_VERSION", "stable")

--- a/iexfinance/base.py
+++ b/iexfinance/base.py
@@ -83,6 +83,9 @@ class _IEXBase(object):
                 "through the environmental variable "
                 "IEX_TOKEN."
             )
+        if self.token.startswith(("Tsk", "Tpk")):
+            logger.info("Using a sandboxed environment because a test key was detected")
+            os.environ["IEX_API_VERSION"] = "iexcloud-sandbox"
         # Get desired API version from environment variables
         # Defaults to IEX Cloud
         self.version = os.getenv("IEX_API_VERSION", "stable")

--- a/iexfinance/tests/conftest.py
+++ b/iexfinance/tests/conftest.py
@@ -1,1 +1,24 @@
+import pytest
+import os
+
 from iexfinance.tests.fixtures import *  # noqa: F403,F401
+
+
+def pytest_sessionstart(session):
+    iex_token = os.getenv("IEX_TOKEN")
+    if not iex_token:
+        pytest.exit(
+            (
+                "IEX_TOKEN not found. Please export a test 'IEX_TOKEN' in your"
+                'environment to run pytests: export IEX_TOKEN="Tpk_..."'
+            ),
+            returncode=1,
+        )
+    if not iex_token.startswith(("Tpk", "Tsk")):
+        pytest.exit(
+            (
+                "The IEX_TOKEN exported is not a test token. This should not be"
+                "used for tests."
+            ),
+            returncode=1,
+        )

--- a/iexfinance/tests/data_apis/test_time_series.py
+++ b/iexfinance/tests/data_apis/test_time_series.py
@@ -1,21 +1,17 @@
 import pandas as pd
-import pytest
 
 from iexfinance.data_apis import get_time_series
 
 
 class TestTimeSeries(object):
-    @pytest.mark.xfail(reason="Endpoint not working in sandbox environment")
-    def test_all_series(self):
+    def test_all_series_default(self):
         data = get_time_series()
+        assert isinstance(data, pd.DataFrame)
+
+    def test_all_series_json(self):
+        data = get_time_series(output_format="json")
 
         assert isinstance(data, list)
-
-    @pytest.mark.xfail(reason="Endpoint not working in sandbox environment")
-    def test_all_series_pandas(self):
-        data = get_time_series(output_format="pandas")
-
-        assert isinstance(data, pd.DataFrame)
 
     def test_params(self):
         data = get_time_series("REPORTED_FINANCIALS", "AAPL", last=1)

--- a/iexfinance/tests/stocks/test_market_movers.py
+++ b/iexfinance/tests/stocks/test_market_movers.py
@@ -16,7 +16,6 @@ class TestMarketMovers(object):
         assert isinstance(li, pd.DataFrame)
         assert len(li) == pytest.approx(10, 1)
 
-    @pytest.mark.xfail(reason="Unstable endpoint.")
     def test_market_losers(self):
         li = get_market_losers()
 

--- a/iexfinance/tests/test_iexdata.py
+++ b/iexfinance/tests/test_iexdata.py
@@ -33,13 +33,11 @@ class TestMarketData(object):
             "LUV",
         ]
 
-    @pytest.mark.xfail(reason="Market data only available during market open")
     def test_last_json_default(self):
         ls = get_last()
 
         assert isinstance(ls, list) and len(ls) > 7500
 
-    @pytest.mark.xfail(reason="Market data only available during market open")
     def test_last_syms(self):
         ls = get_last("AAPL")
         ls2 = get_last(["AAPL", "TSLA"])
@@ -69,12 +67,10 @@ class TestMarketData(object):
         with pytest.raises(ValueError):
             get_tops(self.bad)
 
-    @pytest.mark.xfail(reason="Market data only available during market open")
     def test_DEEP_default(self):
         with pytest.raises(ValueError):
             get_deep()
 
-    @pytest.mark.xfail(reason="Market data only available during market open")
     def test_DEEP_syms(self):
         js = get_deep("AAPL")
 
@@ -106,7 +102,6 @@ class TestStats(object):
         js = get_stats_intraday()
         assert isinstance(js, dict)
 
-    @pytest.mark.xfail(reason="IEX recent API endpoint unstable.")
     def test_recent(self):
         ls = get_stats_recent()
         assert isinstance(ls, list)
@@ -116,13 +111,14 @@ class TestStats(object):
         assert isinstance(js, dict)
 
 
-@pytest.mark.xfail(reason="Endpoint in development by provider.")
 class TestStatsDaily(object):
+    @pytest.mark.xfail(reason="Endpoint in development by provider.")
     def test_daily_last(self):
         ls = get_stats_daily(last=5)
         assert isinstance(ls, list)
         assert len(ls) == 5
 
+    @pytest.mark.xfail(reason="Endpoint in development by provider.")
     def test_daily_dates(self):
         ls = get_stats_daily(start=datetime(2017, 1, 1), end=datetime(2017, 2, 1))
         assert isinstance(ls, list)

--- a/test.sh
+++ b/test.sh
@@ -27,14 +27,6 @@ echo "PASSED"
 
 echo "pytest..."
 
-if [[ -z ${IEX_TOKEN} ]]; then
-	exit "IEX_TOKEN not found. Please export a test test 'IEX_TOKEN' in your environment to run pytests: export IEX_TOKEN=\"Tpk_...\""
-fi
-
-if [[ !(${IEX_TOKEN} != "Tpk*" && ${IEX_TOKEN} != "Tsk*") ]]; then
-	exit "The IEX_TOKEN exported is not a test token. This should not be used for tests."
-fi
-
 pytest -x iexfinance/tests
 rc=$?;
 

--- a/test.sh
+++ b/test.sh
@@ -20,11 +20,21 @@ echo "flake8-rst docs check..."
 flake8-rst --filename="*.rst" .
 rc=$?; if [[ $rc != 0 ]]; then
     echo "flake8-rst docs check failed."
+		echo "Run the pytests manually in case you're hitting this bug: https://github.com/kataev/flake8-rst/issues/24."
     exit $rc;
 fi
 echo "PASSED"
 
 echo "pytest..."
+
+if [[ -z ${IEX_TOKEN} ]]; then
+	exit "IEX_TOKEN not found. Please export a test test 'IEX_TOKEN' in your environment to run pytests: export IEX_TOKEN=\"Tpk_...\""
+fi
+
+if [[ !(${IEX_TOKEN} != "Tpk*" && ${IEX_TOKEN} != "Tsk*") ]]; then
+	exit "The IEX_TOKEN exported is not a test token. This should not be used for tests."
+fi
+
 pytest -x iexfinance/tests
 rc=$?;
 


### PR DESCRIPTION
- Remove `xfail` decorators from tests that passed.
- Add a couple instructions and details to `test.sh`
  script on token usage and potential failures
- Automatically change to sandbox environment if
  IEX token starts with 'Tsk' or 'Tpk'.

Pytests:
```
======================================================== test session starts =========================================================
platform darwin -- Python 3.7.7, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/olshansky/workspace/iexfinance, configfile: pytest.ini
collected 168 items

iexfinance/tests/test_account.py ssssssss                                                                                      [  4%]
iexfinance/tests/test_altdata.py ...sssss..                                                                                    [ 10%]
iexfinance/tests/test_apidata.py .                                                                                             [ 11%]
iexfinance/tests/test_auth.py ....                                                                                             [ 13%]
iexfinance/tests/test_base.py .....                                                                                            [ 16%]
iexfinance/tests/test_iexdata.py ...xx.....x....xx.......                                                                      [ 30%]
iexfinance/tests/test_refdata.py ......                                                                                        [ 34%]
iexfinance/tests/test_utils.py ..................                                                                              [ 45%]
iexfinance/tests/data_apis/test_data_points.py ....                                                                            [ 47%]
iexfinance/tests/data_apis/test_time_series.py ...                                                                             [ 49%]
iexfinance/tests/stocks/test_collections.py ...                                                                                [ 51%]
iexfinance/tests/stocks/test_earnings_today.py .                                                                               [ 51%]
iexfinance/tests/stocks/test_eod_options.py ..x                                                                                [ 53%]
iexfinance/tests/stocks/test_field_methods.py .................                                                                [ 63%]
iexfinance/tests/stocks/test_fundamentals.py ..............                                                                    [ 72%]
iexfinance/tests/stocks/test_historical.py ........                                                                            [ 76%]
iexfinance/tests/stocks/test_ipo_calendar.py x.                                                                                [ 77%]
iexfinance/tests/stocks/test_market_movers.py .....                                                                            [ 80%]
iexfinance/tests/stocks/test_market_volume.py .                                                                                [ 81%]
iexfinance/tests/stocks/test_news.py .                                                                                         [ 82%]
iexfinance/tests/stocks/test_prices.py .............                                                                           [ 89%]
iexfinance/tests/stocks/test_profiles.py ......                                                                                [ 93%]
iexfinance/tests/stocks/test_research.py ...
..x                                                                                [ 97%]
iexfinance/tests/stocks/test_sector_performance.py .                                                                           [ 97%]
iexfinance/tests/stocks/test_stocks_base.py ....                                                                               [100%]

======================================= 147 passed, 13 skipped, 8 xfailed in 62.51s (0:01:02) ========================================
```

- [ ] closes #xxxx
- [ ] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black iexfinance`
- [ ] added entry to docs/source/whatsnew/vLATEST.txt