### PR TITLE
Add include_today option to HistoricalReader

### DIFF
--- a/docs/source/whatsnew/v0.5.1.txt
+++ b/docs/source/whatsnew/v0.5.1.txt
@@ -12,6 +12,7 @@ Enhancements
 - Re-added dropped ``date`` column in some calls (:issue:`238`)
 - Added support for `Crytpocurrency Book <https://iexcloud.io/docs/api/#cryptocurrency-book>`__ - ``iexfinance.crypto.get_crypto_book``
 - Added support for `Cryptocurrency Price <https://iexcloud.io/docs/api/#cryptocurrency-price>`__ - ``iexfinance.crypto.get_crypto_price``
+- Added `include_today` option for `HistoricalReader` and `get_historical_data`
 
 Bug Fixes
 ~~~~~~~~~

--- a/iexfinance/stocks/__init__.py
+++ b/iexfinance/stocks/__init__.py
@@ -10,7 +10,9 @@ from iexfinance.stocks.todayearnings import EarningsReader
 from iexfinance.utils.exceptions import ImmediateDeprecationError
 
 
-def get_historical_data(symbols, start=None, end=None, close_only=False, **kwargs):
+def get_historical_data(
+    symbols, start=None, end=None, close_only=False, include_today=False, **kwargs
+):
     """
     Function to obtain historical date for a symbol or list of
     symbols. Return an instance of HistoricalReader
@@ -30,6 +32,8 @@ def get_historical_data(symbols, start=None, end=None, close_only=False, **kwarg
     close_only: bool, default False
         Returns adjusted data only with keys ``date``, ``close``, and
         ``volume``
+    include_today: bool, default False
+        Appends data from the current trading day
     kwargs:
         Additional Request Parameters (see base class)
 
@@ -39,7 +43,12 @@ def get_historical_data(symbols, start=None, end=None, close_only=False, **kwarg
         Historical stock prices over date range, start to end
     """
     return HistoricalReader(
-        symbols, start=start, end=end, close_only=close_only, **kwargs
+        symbols,
+        start=start,
+        end=end,
+        close_only=close_only,
+        include_today=include_today,
+        **kwargs
     ).fetch()
 
 

--- a/iexfinance/stocks/historical.py
+++ b/iexfinance/stocks/historical.py
@@ -14,10 +14,19 @@ class HistoricalReader(Stock):
     Reference: https://iextrading.com/developer/docs/#chart
     """
 
-    def __init__(self, symbols, start=None, end=None, close_only=False, **kwargs):
+    def __init__(
+        self,
+        symbols,
+        start=None,
+        end=None,
+        close_only=False,
+        include_today=False,
+        **kwargs
+    ):
         start = start or datetime.datetime.today() - datetime.timedelta(days=365)
         self.start, self.end = _sanitize_dates(start, end)
         self.close_only = close_only
+        self.include_today = include_today
         super(HistoricalReader, self).__init__(symbols, **kwargs)
 
     @property
@@ -58,6 +67,7 @@ class HistoricalReader(Stock):
             "range": self.chart_range,
             "chartByDay": self.single_day,
             "chartCloseOnly": self.close_only,
+            "includeToday": self.include_today,
         }
         if self.single_day:
             try:


### PR DESCRIPTION
As the title says, just a quick change to allow passing `include_today=True` to `get_historical_data` and `HistoricalReader`. Thanks for a great library!

- [x] tests added / passed
- [x] passes `black iexfinance`
- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] added entry to docs/source/whatsnew/vLATEST.txt